### PR TITLE
fix: serialize release workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
 
   release-agent:
     uses: canonical/observability/.github/workflows/charm-release.yaml@main
+    needs: release-region
     secrets: inherit
     with:
       charm-path: maas-agent


### PR DESCRIPTION
This is needed since due to the concurrency group defined in observability release workflow, every new invocation will cancel the previous one. In other words, we can have at most one workflow running.