### PR TITLE
ci: add tag prefix for each charm release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,7 @@ jobs:
     secrets: inherit
     with:
       charm-path: maas-region
+      release-tag-prefix: maas-region
       provider: lxd
 
   detect-agent-changes:
@@ -72,4 +73,5 @@ jobs:
     secrets: inherit
     with:
       charm-path: maas-agent
+      release-tag-prefix: maas-agent
       provider: lxd


### PR DESCRIPTION
This PR is making use of the new observability release action [feature](https://github.com/canonical/observability/pull/164) that is setting an optional git tag prefix for the GitHub releases that accompany charm releases. This is needed to avoid situations where many charms live in the same repo and the current pending to be released revision of one charm matches an older revision of the other charm.

This input value is finally applied to the `charming-actions/release-charm` action [1] that is called inside observability release action [2].

**Links:**
[1] https://github.com/canonical/charming-actions/blob/83a27879303e4de116ffbace69da2bff12c9fd64/release-charm/README.md?plain=1#L64
[2] https://github.com/canonical/observability/blob/main/.github/workflows/_charm-release.yaml#L150