### PR TITLE
ci: qa the release of many charms

### DIFF
--- a/maas-agent/tests/unit/test_charm.py
+++ b/maas-agent/tests/unit/test_charm.py
@@ -47,7 +47,7 @@ class TestEnrollment(unittest.TestCase):
     def setUp(self):
         self.remote_app = "maas-region"
         self.agent_name = socket.getfqdn()
-        self.maas_secret = "my-secret"
+        self.maas_secret = "my_secret"
         self.api_url = "http://region:5240/MAAS"
         self.harness = ops.testing.Harness(MaasRackCharm)
         self.harness.add_network("10.0.0.10")

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -71,12 +71,12 @@ class TestDBRelation(unittest.TestCase):
                 "endpoints": "30.0.0.1:5432",
                 "read-only-endpoints": "30.0.0.2:5432",
                 "username": "test_maas_db",
-                "password": "my_password",
+                "password": "my_secret",
             },
         )
         mock_helper.setup_region.assert_called_once_with(
             f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS",
-            "postgres://test_maas_db:my_password@30.0.0.1:5432/maas_region_db",
+            "postgres://test_maas_db:my_secret@30.0.0.1:5432/maas_region_db",
             "region",
         )
 


### PR DESCRIPTION
This PR is changing the values of variables inside unit tests of each charm so that we can QA the multiple release under different tag prefixes. In addition, it is using the same value for the dummy variable which is a minor not so important improvement