### PR TITLE
ci: pin update-libs action to avoid commits from observability bot

### DIFF
--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,14 +9,14 @@ on:
 jobs:
   update-lib-region:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@main
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@5b3d2836bb45cb435e78e8d7d041f643d440ece5
     secrets: inherit
     with:
       charm-path: maas-region
 
   update-lib-agent:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@main
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@5b3d2836bb45cb435e78e8d7d041f643d440ece5
     secrets: inherit
     with:
       charm-path: maas-agent


### PR DESCRIPTION
With this [PR](https://github.com/canonical/observability/pull/165) during update-libs, the observability GH action will try to commit a change in the libs by statically setting observability bot as the commiter.

This PR is pining the update libs to the previous commit to avoid commits from observability bot for two reasons:

- The observability bot is not owned by MAAS team
- The action is expecting to find the GPG key and passphrase of the bot to repository secrets. With those, the action will sign the commit. While we can use a key that `maas-lander` bot owns, we will end up with unverified commits since the email of the GPG key will not match the committer/author email