### PR TITLE
ci: fix lint issues

### DIFF
--- a/maas-agent/lib/charms/maas_region/v0/maas.py
+++ b/maas-agent/lib/charms/maas_region/v0/maas.py
@@ -21,7 +21,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 DEFAULT_ENDPOINT_NAME = "maas-region"
@@ -45,7 +45,7 @@ class MaasDatabag:
         init_vals = {}
         for f in dataclasses.fields(cls):
             val = data.get(f.name)
-            init_vals[f.name] = val if f.type == str else json.loads(val)  # type: ignore
+            init_vals[f.name] = val if f.type == str else json.loads(val)  # type: ignore  # noqa: E721
         return cls(**init_vals)
 
     def dump(self, databag: Union[MutableMapping[str, str], None] = None) -> None:
@@ -56,7 +56,7 @@ class MaasDatabag:
             databag.clear()
         for f in dataclasses.fields(self):
             val = getattr(self, f.name)
-            databag[f.name] = val if f.type == str else json.dumps(val)
+            databag[f.name] = val if f.type == str else json.dumps(val)  # noqa: E721
 
 
 @dataclasses.dataclass

--- a/maas-agent/src/charm.py
+++ b/maas-agent/src/charm.py
@@ -27,7 +27,7 @@ MAAS_RACK_PORTS = [
     ops.Port("udp", 123),  # chrony
     ops.Port("udp", 323),  # chrony
     ops.Port("tcp", 53),  # named
-    ops.Port("tcp", 5240),  # nginx master
+    ops.Port("tcp", 5240),  # nginx primary
     *[ops.Port("tcp", p) for p in range(5241, 5247 + 1)],  # Internal services
     ops.Port("tcp", 5248),
     ops.Port("tcp", MAAS_RACK_METRICS_PORT),

--- a/maas-agent/tox.ini
+++ b/maas-agent/tox.ini
@@ -6,6 +6,7 @@ no_package = True
 skip_missing_interpreters = True
 env_list = format, lint, static-{charm,lib}, unit, scenario
 min_version = 4.0.0
+basepython = py38
 
 [vars]
 src_path = {tox_root}/src

--- a/maas-region/lib/charms/maas_region/v0/maas.py
+++ b/maas-region/lib/charms/maas_region/v0/maas.py
@@ -21,7 +21,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 DEFAULT_ENDPOINT_NAME = "maas-region"
@@ -45,7 +45,7 @@ class MaasDatabag:
         init_vals = {}
         for f in dataclasses.fields(cls):
             val = data.get(f.name)
-            init_vals[f.name] = val if f.type == str else json.loads(val)  # type: ignore
+            init_vals[f.name] = val if f.type == str else json.loads(val)  # type: ignore  # noqa: E721
         return cls(**init_vals)
 
     def dump(self, databag: Union[MutableMapping[str, str], None] = None) -> None:
@@ -56,7 +56,7 @@ class MaasDatabag:
             databag.clear()
         for f in dataclasses.fields(self):
             val = getattr(self, f.name)
-            databag[f.name] = val if f.type == str else json.dumps(val)
+            databag[f.name] = val if f.type == str else json.dumps(val)  # noqa: E721
 
 
 @dataclasses.dataclass

--- a/maas-region/tox.ini
+++ b/maas-region/tox.ini
@@ -6,6 +6,7 @@ no_package = True
 skip_missing_interpreters = True
 env_list = format, lint, static-{charm,lib}, unit, scenario
 min_version = 4.0.0
+basepython = py38
 
 [vars]
 src_path = {tox_root}/src


### PR DESCRIPTION
- Fix linting issues which are preventing the CI from running integration tests
- Pin Python to 3.8 in tox to align with the Python version that GH actions are using