### PR TITLE
ci: renovate ignore observability updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "ignoreDeps": [
+    "canonical/observability"
   ]
 }


### PR DESCRIPTION
- Ignore updates on `canonical/observability` actions since we have pinned the version on purpose: #39