### PR TITLE
ci: publish charms to track edges based on branch name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - track/*
 
 jobs:
   detect-region-changes:


### PR DESCRIPTION
Add the option to publish charm to different track on edge risk level.

The maas-charms repo is using observability GitHub actions for its CI. When releasing charms to edge channels, observability CI is using canonical/charming-actions/channel to determine the channel where to release the charm. This action determines the track of the channel based on the GitHub branch name. Based on the docs, to release to a specific track rather than the default/latest, the event should be kind push and the branch name should start with `track/`.

**References:**

- [observability/charm-release](https://github.com/canonical/observability/blob/main/.github/workflows/charm-release.yaml#L62)
- [observability/_charm-release](https://github.com/canonical/observability/blob/main/.github/workflows/_charm-release.yaml#L134)
- [canonical/charming-actions/channel](https://github.com/canonical/charming-actions/tree/2.1.1/channel#branch-selection)