### PR TITLE
ci: sign lib update commits with maas-lander GPG

### DIFF
--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,14 +9,19 @@ on:
 jobs:
   update-lib-region:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@5b3d2836bb45cb435e78e8d7d041f643d440ece5
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@main
     secrets: inherit
     with:
       charm-path: maas-region
+      commit-username: maas-lander
+      commit-email: 115650013+maas-lander@users.noreply.github.com
 
   update-lib-agent:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@5b3d2836bb45cb435e78e8d7d041f643d440ece5
+    needs: update-lib-region
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@main
     secrets: inherit
     with:
       charm-path: maas-agent
+      commit-username: maas-lander
+      commit-email: 115650013+maas-lander@users.noreply.github.com


### PR DESCRIPTION
- Stop pinning to old version of the observability GH action since the username/email of the committer are no longer hard coded and they can be configured
- Use maas-lander username/GH email to create commits when updating dependent libraries
- Make sure that the jobs are not running in parallel to avoid maas-agent jobs closing PRs that have been opened by maas-region jobs during the same GH action runs

Follows: https://github.com/canonical/observability/pull/170