### PR TITLE
feat: add configuration entry for TLS termination at HA Proxy

### DIFF
--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -131,5 +131,5 @@ config:
   options:
     tls_mode:
       default: ""
-      description: Whether to enable TLS termination at HA Proxy ('termination'), TLS passthrough ('passthrough'), or no TLS ('')
+      description: Whether to enable TLS termination at HA Proxy ('termination'), or no TLS ('')
       type: string

--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -128,8 +128,8 @@ parts:
       - src/loki/loki.yml
 
 config:
-  tls-mode:
-    name:
+  options:
+    tls_mode:
       default: ""
       description: Whether to enable TLS termination at HA Proxy ('termination'), TLS passthrough ('passthrough'), or no TLS ('')
       type: string

--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -126,3 +126,10 @@ parts:
       "*": src/loki/
     prime:
       - src/loki/loki.yml
+
+config:
+  tls-mode:
+    name:
+      default: ""
+      description: Whether to enable TLS termination at HA Proxy ('termination'), TLS passthrough ('passthrough'), or no TLS ('')
+      type: string

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -59,8 +59,7 @@ class MaasRegionCharm(ops.CharmBase):
     _TLS_MODES = [
         "",
         "termination",
-        "passthrough",
-    ]  # no TLS, termination at HA Proxy, TLS passthrough
+    ]  # no TLS, termination at HA Proxy
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -436,13 +435,12 @@ class MaasRegionCharm(ops.CharmBase):
         else:
             event.fail("MAAS is not initialized yet")
 
-    def _on_config_changed(self, event: ops.ActionEvent):
+    def _on_config_changed(self, event: ops.ConfigChangedEvent):
         tls_mode = self.config["tls_mode"]
         if tls_mode not in self._TLS_MODES:
             msg = f"Invalid tls_mode configuration: '{tls_mode}'. Valid options are: {self._TLS_MODES}"
             self.unit.status = ops.BlockedStatus(msg)
-            event.fail(msg)
-            return
+            raise ValueError(msg)
         self._update_ha_proxy()
 
 

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -439,7 +439,7 @@ class MaasRegionCharm(ops.CharmBase):
             event.fail("MAAS is not initialized yet")
 
     def _on_config_changed(self, event: ops.ActionEvent):
-        tls_mode = self.config["tls-mode"]
+        tls_mode = self.config["tls_mode"]
         if tls_mode not in self._TLS_MODES:
             self.unit.status = ops.BlockedStatus(
                 f"Invalid tls-mode configuration: '{tls_mode}'. Valid options are: {self._TLS_MODES}"

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -264,6 +264,19 @@ class MaasRegionCharm(ops.CharmBase):
                             [],
                         )
                     ],
+                },
+                {
+                    "service_name": "agent-service",
+                    "service_host": "0.0.0.0",
+                    "service_port": MAAS_PROXY_PORT,
+                    "servers": [
+                        (
+                            f"{app_name}-{self.unit.name.replace('/', '-')}",
+                            self.bind_address,
+                            MAAS_HTTP_PORT,
+                            [],
+                        )
+                    ]
                 }
             ]
             relation.data[self.unit]["services"] = yaml.safe_dump(data)

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -279,7 +279,7 @@ class MaasRegionCharm(ops.CharmBase):
             if self.config["tls_mode"] == "termination":
                 data.append(
                     {
-                        "service_name": "agent-service",
+                        "service_name": "agent_service",
                         "service_host": "0.0.0.0",
                         "service_port": MAAS_PROXY_PORT,
                         "servers": [
@@ -292,9 +292,7 @@ class MaasRegionCharm(ops.CharmBase):
                         ],
                     }
                 )
-            elif self.config["tls_mode"] == "passthrough":
-                # TODO: Implement
-                pass
+            # TODO: Implement passthrough configuration
             relation.data[self.unit]["services"] = yaml.safe_dump(data)
 
     def _on_start(self, _event: ops.StartEvent) -> None:
@@ -442,9 +440,7 @@ class MaasRegionCharm(ops.CharmBase):
         tls_mode = self.config["tls_mode"]
         if tls_mode not in self._TLS_MODES:
             msg = f"Invalid tls_mode configuration: '{tls_mode}'. Valid options are: {self._TLS_MODES}"
-            self.unit.status = ops.BlockedStatus(
-                msg
-            )
+            self.unit.status = ops.BlockedStatus(msg)
             event.fail(msg)
             return
         self._update_ha_proxy()

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -136,6 +136,19 @@ class TestClusterUpdates(unittest.TestCase):
         self.assertEqual(ha_data[1]["servers"][0][1], "10.0.0.10")
 
     @patch("charm.MaasHelper", autospec=True)
+    def test_invalid_tls_mode(self, mock_helper):
+        self.harness.set_leader(True)
+        self.harness.begin()
+        ha = self.harness.add_relation(
+            MAAS_API_RELATION, "haproxy", unit_data={"public-address": "proxy.maas"}
+        )
+        with self.assertRaises(ValueError):
+            self.harness.update_config({"tls_mode": "invalid_mode"})
+
+        ha_data = yaml.safe_load(self.harness.get_relation_data(ha, "maas-region/0")["services"])
+        self.assertEqual(len(ha_data), 1)
+
+    @patch("charm.MaasHelper", autospec=True)
     def test_on_maas_cluster_changed_new_agent(self, mock_helper):
         mock_helper.get_maas_mode.return_value = "region"
         mock_helper.get_maas_secret.return_value = "very-secret"

--- a/maas-region/tests/unit/test_helper.py
+++ b/maas-region/tests/unit/test_helper.py
@@ -7,6 +7,7 @@ import unittest
 from unittest.mock import MagicMock, PropertyMock, mock_open, patch
 
 from charms.operator_libs_linux.v2.snap import SnapState
+
 from helper import MAAS_SERVICE, MaasHelper
 
 


### PR DESCRIPTION
This PR adds a `tls_mode` configuration option, which determines how HA Proxy's `services` yaml configuration should be updated. TLS Passthrough will come in a second PR.

This version is released to channel `latest/edge/wyatt-test`