### PR TITLE
ci: exclude maas-lander from CLA check

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -5,8 +5,7 @@ on: [pull_request_target]
 jobs:
   cla-check:
     runs-on: ubuntu-latest
+    if: github.actor != 'maas-lander'
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v1
-        with:
-          exempted-bots: maas-lander,dependabot,github-actions,renovate


### PR DESCRIPTION
Proper way to exclude maas-lander from cla-checks.

Follow-up of: #195 