### PR TITLE
feat: add configuration entry for TLS termination at HA Proxy (#194)

### DIFF
--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -126,3 +126,10 @@ parts:
       "*": src/loki/
     prime:
       - src/loki/loki.yml
+
+config:
+  options:
+    tls_mode:
+      default: ""
+      description: Whether to enable TLS termination at HA Proxy ('termination'), or no TLS ('')
+      type: string


### PR DESCRIPTION
adds a tls_mode configuration option, which determines how HA Proxy's services yaml configuration should be updated

(cherry picked from commit ac0ba6960dc3736eda687d7b679a94ab32895f74)