### PR TITLE
feat: add grafana dashboard as a part of the charm

### DIFF
--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -130,6 +130,16 @@ parts:
     prime:
       - src/loki/loki.yml
 
+  grafana-dashboards:
+    plugin: dump
+    source: https://github.com/canonical/maas-grafana-dashboards
+    source-depth: 1
+    source-type: git
+    organize:
+      "*": src/grafana_dashboards/
+    prime:
+      - src/grafana_dashboards/maas_stats.json
+
 config:
   options:
     tls_mode:

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -116,7 +116,7 @@ class MaasRegionCharm(ops.CharmBase):
             ],
             metrics_rules_dir="./src/prometheus",
             logs_rules_dir="./src/loki",
-            # dashboard_dirs=["./src/grafana_dashboards"],
+            dashboard_dirs=["./src/grafana_dashboards"],
         )
         self.tracing = TracingEndpointRequirer(self, protocols=["otlp_http"])
         self.charm_tracing_endpoint, _ = charm_tracing_config(self.tracing, None)


### PR DESCRIPTION
This PR introduces the integration with the grafana dashboard defined in our [maas-grafana-dashboards](https://github.com/canonical/maas-grafana-dashboards/) repo.