### PR TITLE
chore: update charmcraft.yaml parts to use subdirectory for grafana dashboards directory

### DIFF
--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -135,8 +135,9 @@ parts:
     source: https://github.com/canonical/maas-grafana-dashboards
     source-depth: 1
     source-type: git
+    source-subdir: maas
     organize:
-      "*": src/grafana_dashboards/
+      maas_stats.json: src/grafana_dashboards/maas_stats.json
     prime:
       - src/grafana_dashboards/maas_stats.json
 

--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -137,9 +137,9 @@ parts:
     source-type: git
     source-subdir: maas
     organize:
-      maas_stats.json: src/grafana_dashboards/maas_stats.json
+      "*": src/grafana_dashboards/
     prime:
-      - src/grafana_dashboards/maas_stats.json
+      - src/grafana_dashboards/*
 
 config:
   options:


### PR DESCRIPTION
This PR requires https://github.com/canonical/maas-grafana-dashboards/pull/1 to be merged, which splits the dashboards into directories