### PR TITLE
ci: fix auto-update charm libraries automated flow

### DIFF
--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -16,9 +16,23 @@ jobs:
       commit-username: maas-lander
       commit-email: 115650013+maas-lander@users.noreply.github.com
 
+  detect-open-prs:
+    name: Check open library updates PRs
+    needs: update-lib-region
+    runs-on: ubuntu-22.04
+    outputs:
+      open_prs: ${{ steps.open-prs.outputs.open_prs }}
+    steps:
+      - name: Check for any pre-existing PR and save it in the output
+        id: open-prs
+        run: |
+          OPEN_PRS="$(gh pr list --head chore/auto-libs --state open --json id --jq 'length')"
+          echo "open_prs=$OPEN_PRS" >> "$GITHUB_OUTPUT"
+
   update-lib-agent:
     name: Check libraries
-    needs: update-lib-region
+    needs: detect-open-prs
+    if: needs.detect-open-prs.outputs.open_prs == '0'
     uses: canonical/observability/.github/workflows/charm-update-libs.yaml@main
     secrets: inherit
     with:


### PR DESCRIPTION
Add an intermediate check between update lib GH actions so that to avoid faulty behaviors when maas-region has an update and maas-agent does not.