### PR TITLE
fix: enable prometheus metrics by default

### DIFF
--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -162,4 +162,4 @@ config:
     enable_prometheus_metrics:
       default: true
       description: Whether to enable Prometheus metrics for MAAS
-      type: bool
+      type: boolean

--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -159,3 +159,7 @@ config:
       default: ""
       description: CA Certificates chain in PEM format
       type: string
+    enable_prometheus_metrics:
+      default: true
+      description: Whether to enable Prometheus metrics for MAAS
+      type: bool

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -369,7 +369,7 @@ class MaasRegionCharm(ops.CharmBase):
         if secret_uri := self.get_peer_data(self.app, MAAS_ADMIN_SECRET_KEY):
             secret = self.model.get_secret(id=secret_uri)
             username = secret.get_content()["username"]
-            MaasHelper.set_prometheus_metrics(username, self.bind_address, enable) # type: ignore
+            MaasHelper.set_prometheus_metrics(username, self.bind_address, enable)  # type: ignore
 
     def _on_start(self, _event: ops.StartEvent) -> None:
         """Handle the MAAS controller startup.

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -287,7 +287,7 @@ class MaasRegionCharm(ops.CharmBase):
                 self._update_tls_config()
                 credentials = self._create_or_get_internal_admin()
                 MaasHelper.set_prometheus_metrics(
-                    credentials["username"], self.config["enable_prometheus_metrics"]  # type: ignore
+                    credentials["username"], self.bind_address, self.config["enable_prometheus_metrics"]  # type: ignore
                 )
             return True
         except subprocess.CalledProcessError:
@@ -369,7 +369,7 @@ class MaasRegionCharm(ops.CharmBase):
         if secret_uri := self.get_peer_data(self.app, MAAS_ADMIN_SECRET_KEY):
             secret = self.model.get_secret(id=secret_uri)
             username = secret.get_content()["username"]
-            MaasHelper.set_prometheus_metrics(username, enable)
+            MaasHelper.set_prometheus_metrics(username, self.bind_address, enable) # type: ignore
 
     def _on_start(self, _event: ops.StartEvent) -> None:
         """Handle the MAAS controller startup.
@@ -462,7 +462,7 @@ class MaasRegionCharm(ops.CharmBase):
             return
         creds = self._create_or_get_internal_admin()
         MaasHelper.set_prometheus_metrics(
-            creds["username"], self.config["enable_prometheus_metrics"]  # type: ignore
+            creds["username"], self.bind_address, self.config["enable_prometheus_metrics"]  # type: ignore
         )
         if cur_mode := MaasHelper.get_maas_mode():
             if self.get_operational_mode() != cur_mode:

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -267,11 +267,12 @@ class MaasRegionCharm(ops.CharmBase):
                     )
                     content = {"username": "maas-admin-internal", "password": password}
 
-                    secret = self.app.add_secret(content, label=MAAS_ADMIN_SECRET_LABEL)
-                    self.set_peer_data(self.app, MAAS_ADMIN_SECRET_KEY, secret.id)
                     MaasHelper.create_admin_user(content["username"], password, "", None)
                     # enable prometheus metrics with our new admin account
                     MaasHelper.set_prometheus_metrics(content["username"], True)
+
+                    secret = self.app.add_secret(content, label=MAAS_ADMIN_SECRET_LABEL)
+                    self.set_peer_data(self.app, MAAS_ADMIN_SECRET_KEY, secret.id)
             return True
         except subprocess.CalledProcessError:
             return False

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -436,6 +436,10 @@ class MaasRegionCharm(ops.CharmBase):
             event.set_results({"info": f"user {username} successfully created"})
         except subprocess.CalledProcessError:
             event.fail(f"Failed to create user {username}")
+        try:
+            MaasHelper.enable_prometheus_metrics(username)
+        except subprocess.CalledProcessError:
+            event.fail("Failed to enable prometheus metrics")
 
     def _on_get_api_key_action(self, event: ops.ActionEvent):
         """Handle the get-api-key action.

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -6,7 +6,9 @@
 
 import json
 import logging
+import random
 import socket
+import string
 import subprocess
 from typing import Any, List, Union
 
@@ -17,6 +19,7 @@ from charms.grafana_agent.v0 import cos_agent
 from charms.maas_region.v0 import maas
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer, charm_tracing_config
+from ops.model import SecretNotFoundError
 
 from helper import MaasHelper
 
@@ -53,6 +56,9 @@ MAAS_REGION_PORTS = [
     *[ops.Port("tcp", p) for p in range(5270, 5274 + 1)],  # Temporal
     *[ops.Port("tcp", p) for p in range(5280, 5284 + 1)],  # Temporal
 ]
+
+MAAS_ADMIN_SECRET_LABEL = "maas-admin"
+MAAS_ADMIN_SECRET_KEY = "maas-admin-secret-uri"
 
 
 @trace_charm(
@@ -251,6 +257,21 @@ class MaasRegionCharm(ops.CharmBase):
             # check maas_api_url existence in case MAAS isn't ready yet
             if self.maas_api_url and self.unit.is_leader():
                 self._update_tls_config()
+                # create admin account for internal use if not already there
+                try:
+                    self.model.get_secret(label=MAAS_ADMIN_SECRET_LABEL)
+                except SecretNotFoundError:
+                    password = "".join(
+                        random.SystemRandom().choice(string.ascii_letters + string.digits)
+                        for _ in range(15)
+                    )
+                    content = {"username": "maas-admin-internal", "password": password}
+
+                    secret = self.app.add_secret(content, label=MAAS_ADMIN_SECRET_LABEL)
+                    self.set_peer_data(self.app, MAAS_ADMIN_SECRET_KEY, secret.id)
+                    MaasHelper.create_admin_user(content["username"], password, "", None)
+                    # enable prometheus metrics with our new admin account
+                    MaasHelper.set_prometheus_metrics(content["username"], True)
             return True
         except subprocess.CalledProcessError:
             return False
@@ -326,6 +347,12 @@ class MaasRegionCharm(ops.CharmBase):
                 MaasHelper.delete_tls_files()
             elif tls_enabled and self.config["tls_mode"] in ["disabled", "termination"]:
                 MaasHelper.disable_tls()
+
+    def _update_prometheus_config(self, enable: bool) -> None:
+        if secret_uri := self.get_peer_data(self.app, MAAS_ADMIN_SECRET_KEY):
+            secret = self.model.get_secret(id=secret_uri)
+            username = secret.get_content()["username"]
+            MaasHelper.set_prometheus_metrics(username, enable)
 
     def _on_start(self, _event: ops.StartEvent) -> None:
         """Handle the MAAS controller startup.
@@ -436,10 +463,6 @@ class MaasRegionCharm(ops.CharmBase):
             event.set_results({"info": f"user {username} successfully created"})
         except subprocess.CalledProcessError:
             event.fail(f"Failed to create user {username}")
-        try:
-            MaasHelper.enable_prometheus_metrics(username)
-        except subprocess.CalledProcessError:
-            event.fail("Failed to enable prometheus metrics")
 
     def _on_get_api_key_action(self, event: ops.ActionEvent):
         """Handle the get-api-key action.
@@ -488,6 +511,7 @@ class MaasRegionCharm(ops.CharmBase):
         self._update_ha_proxy()
         if self.unit.is_leader():
             self._update_tls_config()
+            self._update_prometheus_config(self.config["enable_prometheus_metrics"])  # type: ignore
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -196,14 +196,15 @@ class MaasHelper:
         subprocess.check_call(cmd)
 
     @staticmethod
-    def enable_prometheus_metrics(admin_username: str) -> None:
-        """Enable prometheus metrics for MAAS.
+    def set_prometheus_metrics(admin_username: str, enable: bool) -> None:
+        """Enable or disable prometheus metrics for MAAS.
 
         Args:
             admin_username (str): The admin username for MAAS
+            enable (bool): True to enable, False to disable
 
         Raises:
-            CalledProcessError: failed to fetch key
+            CalledProcessError: failed to set prometheus_metrics setting
         """
         apikey = (
             subprocess.check_output(["sudo", "maas", "apikey", f"--username={admin_username}"])
@@ -224,7 +225,7 @@ class MaasHelper:
             "maas",
             "set-config",
             "name=prometheus_enabled",
-            "value=True",
+            f"value={enable}",
         ]
         subprocess.check_call(set_cmd)
 

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -201,6 +201,9 @@ class MaasHelper:
 
         Args:
             admin_username (str): The admin username for MAAS
+
+        Raises:
+            CalledProcessError: failed to fetch key
         """
         apikey = (
             subprocess.check_output(["sudo", "maas", "apikey", f"--username={admin_username}"])

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -207,12 +207,12 @@ class MaasHelper:
             CalledProcessError: failed to set prometheus_metrics setting
         """
         apikey = (
-            subprocess.check_output(["sudo", "maas", "apikey", f"--username={admin_username}"])
+            subprocess.check_output(["/snap/bin/maas", "apikey", f"--username={admin_username}"])
             .decode()
             .replace("\n", "")
         )
         login_cmd = [
-            "maas",
+            "/snap/bin/maas",
             "login",
             admin_username,
             "http://localhost:5240/MAAS/api/2.0/",
@@ -220,7 +220,7 @@ class MaasHelper:
         ]
         subprocess.check_call(login_cmd)
         set_cmd = [
-            "maas",
+            "/snap/bin/maas",
             admin_username,
             "maas",
             "set-config",

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -196,6 +196,36 @@ class MaasHelper:
         subprocess.check_call(cmd)
 
     @staticmethod
+    def enable_prometheus_metrics(admin_username: str) -> None:
+        """Enable prometheus metrics for MAAS.
+
+        Args:
+            admin_username (str): The admin username for MAAS
+        """
+        apikey = (
+            subprocess.check_output(["sudo", "maas", "apikey", f"--username={admin_username}"])
+            .decode()
+            .replace("\n", "")
+        )
+        login_cmd = [
+            "maas",
+            "login",
+            admin_username,
+            "http://localhost:5240/MAAS/api/2.0/",
+            apikey,
+        ]
+        subprocess.check_call(login_cmd)
+        set_cmd = [
+            "maas",
+            admin_username,
+            "maas",
+            "set-config",
+            "name=prometheus_enabled",
+            "value=True",
+        ]
+        subprocess.check_call(set_cmd)
+
+    @staticmethod
     def is_tls_enabled() -> Union[bool, None]:
         """Check whether MAAS currently has TLS enabled.
 

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -196,11 +196,12 @@ class MaasHelper:
         subprocess.check_call(cmd)
 
     @staticmethod
-    def set_prometheus_metrics(admin_username: str, enable: bool) -> None:
+    def set_prometheus_metrics(admin_username: str, maas_ip: str, enable: bool) -> None:
         """Enable or disable prometheus metrics for MAAS.
 
         Args:
             admin_username (str): The admin username for MAAS
+            maas_ip (str): IP address of the MAAS API
             enable (bool): True to enable, False to disable
 
         Raises:
@@ -215,7 +216,7 @@ class MaasHelper:
             "/snap/bin/maas",
             "login",
             admin_username,
-            "http://localhost:5240/MAAS/api/2.0/",
+            f"http://{maas_ip}:5240/MAAS/api/2.0/",
             apikey,
         ]
         subprocess.check_call(login_cmd)


### PR DESCRIPTION
The MAAS config item `prometheus_enabled` is set to `false` by default. This enables the charm to set this to `true` by default, while leaving an option to disable it.