### PR TITLE
fix: get-api-key action should strip the api key string

### DIFF
--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -511,7 +511,7 @@ class MaasRegionCharm(ops.CharmBase):
         username = event.params["username"]
         try:
             key = MaasHelper.get_api_key(username)
-            event.set_results({"api-key": key})
+            event.set_results({"api-key": key.strip()})
         except subprocess.CalledProcessError:
             event.fail(f"Failed to get key for user {username}")
 


### PR DESCRIPTION
Strip newline and white space characters from the get-api-key output to avoid including them in the output.

Example which contains newline at the end of a user's token (redacted):

```bash
ubuntu@maas-1:~$ juju run maas-region/0 get-api-key username=admin --format json | jq -r '."maas-region/0".results'
Running operation 37 with 1 task
  - task 38 on unit-maas-region-0

Waiting for task 38...
{
  "api-key": "aaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbb:cccccccccccccccccc\n",
  "return-code": 0
}
```