### PR TITLE
fix(ci): pin observability CI before v1 tag

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@main
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
     with:
       charm-path: ${{ github.event.inputs.charm }}
       promotion: ${{ github.event.inputs.promotion }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   pull-request-region:
     name: PR Region
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@main
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
     secrets: inherit
     with:
       charm-path: maas-region
@@ -17,7 +17,7 @@ jobs:
 
   pull-request-agent:
     name: PR Agent
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@main
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
     secrets: inherit
     with:
       charm-path: maas-agent

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Release MAAS Region charm to edge
     needs: detect-region-changes
     if: needs.detect-region-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@main
+    uses: canonical/observability/.github/workflows/charm-release.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
     secrets: inherit
     with:
       charm-path: maas-region
@@ -70,7 +70,7 @@ jobs:
     name: Release MAAS Agent charm to edge
     needs: detect-agent-changes
     if: needs.detect-agent-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@main
+    uses: canonical/observability/.github/workflows/charm-release.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
     secrets: inherit
     with:
       charm-path: maas-agent

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-lib-region:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@main
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
     secrets: inherit
     with:
       charm-path: maas-region
@@ -40,7 +40,7 @@ jobs:
     name: Check libraries
     needs: detect-open-prs
     if: needs.detect-open-prs.outputs.open_prs == '0'
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@main
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
     secrets: inherit
     with:
       charm-path: maas-agent


### PR DESCRIPTION
Do not include breaking changes of observability CI introduced with: https://github.com/canonical/observability/commit/d54fd4e9b1d50ef199a2ff3923824587ba4379a5

The above commit introduced many changes. Among them, there is the introduction of `suites` that is breaking our CI with errors like the below one:

```
Error when evaluating 'strategy' for job 'integration-test'. canonical/observability/.github/workflows/_charm-quality-checks.yaml@v1 (Line: 249, Col: 16): Matrix vector 'suite' does not contain any values
```