### PR TITLE
fix(ci): pin observability CI to v0 tag

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@v0
     with:
       charm-path: ${{ github.event.inputs.charm }}
       promotion: ${{ github.event.inputs.promotion }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   pull-request-region:
     name: PR Region
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v0
     secrets: inherit
     with:
       charm-path: maas-region
@@ -17,7 +17,7 @@ jobs:
 
   pull-request-agent:
     name: PR Agent
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v0
     secrets: inherit
     with:
       charm-path: maas-agent

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Release MAAS Region charm to edge
     needs: detect-region-changes
     if: needs.detect-region-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
+    uses: canonical/observability/.github/workflows/charm-release.yaml@v0
     secrets: inherit
     with:
       charm-path: maas-region
@@ -70,7 +70,7 @@ jobs:
     name: Release MAAS Agent charm to edge
     needs: detect-agent-changes
     if: needs.detect-agent-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
+    uses: canonical/observability/.github/workflows/charm-release.yaml@v0
     secrets: inherit
     with:
       charm-path: maas-agent

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-lib-region:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v0
     secrets: inherit
     with:
       charm-path: maas-region
@@ -40,7 +40,7 @@ jobs:
     name: Check libraries
     needs: detect-open-prs
     if: needs.detect-open-prs.outputs.open_prs == '0'
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@469a1f09208f0643e6666f7bb49f98f67e2f43fb
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v0
     secrets: inherit
     with:
       charm-path: maas-agent


### PR DESCRIPTION
A follow-up of #326 since pining to a SHA was not enough, due to internal references of Observability actions to main branch.

Using the v0 branch, we also include this commit https://github.com/canonical/observability/commit/e045e1f7012615d9f9bfe0cdbef12ff19c99a114 that is fixing the internal references.