### PR TITLE
fix(ci): workaround for LP-2097079

### DIFF
--- a/maas-agent/tests/integration/test_charm.py
+++ b/maas-agent/tests/integration/test_charm.py
@@ -56,6 +56,8 @@ async def test_region_integration(ops_test: OpsTest):
             "postgresql",
             application_name="postgresql",
             channel="14/stable",
+            # workaround for https://bugs.launchpad.net/maas/+bug/2097079
+            config={"plugin_audit_enable": False},
             trust=True,
         ),
         ops_test.model.wait_for_idle(

--- a/maas-region/tests/integration/test_charm.py
+++ b/maas-region/tests/integration/test_charm.py
@@ -50,6 +50,8 @@ async def test_database_integration(ops_test: OpsTest):
             application_name="postgresql",
             channel="14/stable",
             trust=True,
+            # workaround for https://bugs.launchpad.net/maas/+bug/2097079
+            config={"plugin_audit_enable": False},
         ),
         ops_test.model.wait_for_idle(
             apps=["postgresql"], status="active", raise_on_blocked=True, timeout=1000


### PR DESCRIPTION
Until a proper fix is released for https://bugs.launchpad.net/maas/+bug/2097079 and after the postgresql revision 553 was released to 14/stable, we need to start the postgresql with the pgaudit plugin set to disabled.