### PR TITLE
feat: add config maas_url

### DIFF
--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -146,6 +146,13 @@ parts:
 
 config:
   options:
+    maas_url:
+      default: ""
+      description: |
+        The maas_url to set. If not provided, the maas_url is formulated by the IP of maas-region
+        leader and MAAS API port. If application is related to HAProxy, the proxy port is used
+        instead.
+      type: string
     tls_mode:
       default: "disabled"
       description: Whether to enable TLS termination at HA Proxy ('termination'), at MAAS ('passthrough'), or no TLS ('disabled')

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -7,14 +7,16 @@ import logging
 import subprocess
 from os import remove
 from pathlib import Path
-from typing import Union
+from typing import Dict, Union
 
+import yaml
 from charms.operator_libs_linux.v2.snap import SnapCache, SnapState
 
 MAAS_SNAP_NAME = "maas"
 MAAS_MODE = Path("/var/snap/maas/common/snap_mode")
 MAAS_SECRET = Path("/var/snap/maas/common/maas/secret")
 MAAS_ID = Path("/var/snap/maas/common/maas/maas_id")
+MAAS_CONF = Path("/var/snap/maas/current/regiond.conf")
 MAAS_UUID = Path("/var/snap/maas/common/maas/maas_uuid")
 MAAS_SERVICE = "pebble"
 MAAS_SSL_CERT_FILEPATH = Path("/var/snap/maas/common/cert.pem")
@@ -106,6 +108,19 @@ class MaasHelper:
                 return file.readline().strip()
         except OSError:
             return None
+
+    @staticmethod
+    def get_maas_details() -> Dict[str, str]:
+        """Get MAAS operation mode.
+
+        Returns:
+            Dict[str, str]: MAAS details
+        """
+        try:
+            with MAAS_CONF.open() as file:
+                return yaml.safe_load(file)
+        except (OSError, yaml.YAMLError):
+            return {}
 
     @staticmethod
     def is_running() -> bool:


### PR DESCRIPTION
- Add a config option to explicitly set `maas_url`
- When config changes, run maas init if maas is initialized with a maas_url which is different than the config