### PR TITLE
chore: use Juju 3.6 LTS for testing and releasing the charms

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,6 +13,7 @@ jobs:
     secrets: inherit
     with:
       charm-path: maas-region
+      juju-channel: 3.6/stable
       provider: lxd
 
   pull-request-agent:
@@ -21,4 +22,5 @@ jobs:
     secrets: inherit
     with:
       charm-path: maas-agent
+      juju-channel: 3.6/stable
       provider: lxd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
     secrets: inherit
     with:
       charm-path: maas-region
+      juju-channel: 3.6/stable
       release-tag-prefix: maas-region
       provider: lxd
 
@@ -74,5 +75,6 @@ jobs:
     secrets: inherit
     with:
       charm-path: maas-agent
+      juju-channel: 3.6/stable
       release-tag-prefix: maas-agent
       provider: lxd


### PR DESCRIPTION
- Bump Juju used for integration tests and release to 3.6/stable (LTS)