### PR TITLE
fix: return empty dict if yaml.safe_load is None

### DIFF
--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -118,7 +118,7 @@ class MaasHelper:
         """
         try:
             with MAAS_CONF.open() as file:
-                return yaml.safe_load(file)
+                return yaml.safe_load(file) or {}
         except (OSError, yaml.YAMLError):
             return {}
 


### PR DESCRIPTION
When trying to read the `/var/snap/maas/current/regiond.conf` to get details of an initialized MAAS, if MAAS is not initialized, the file exists and it is empty. Since `yaml.safe_load` is producing `None`, return an empty dict `{}` instead.