### PR TITLE
fix: return empty dict if yaml.safe_load is None (#480)

### DIFF
--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -118,7 +118,7 @@ class MaasHelper:
         """
         try:
             with MAAS_CONF.open() as file:
-                return yaml.safe_load(file)
+                return yaml.safe_load(file) or {}
         except (OSError, yaml.YAMLError):
             return {}
 


### PR DESCRIPTION
(cherry picked from commit 5b8880e4a42ca9e231324206f06c0b19cf8c6aa7)