### PR TITLE
feat: build charms for arm64 architecture

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,7 @@ jobs:
       juju-channel: 3.6/stable
       release-tag-prefix: maas-region
       provider: lxd
+      build-for-arm: true
 
   detect-agent-changes:
     name: Detect changes to maas-agent charm
@@ -78,3 +79,4 @@ jobs:
       juju-channel: 3.6/stable
       release-tag-prefix: maas-agent
       provider: lxd
+      build-for-arm: true

--- a/maas-agent/charmcraft.yaml
+++ b/maas-agent/charmcraft.yaml
@@ -33,6 +33,7 @@ links:
 
 platforms:
   ubuntu@24.04:amd64:
+  ubuntu@24.04:arm64:
 
 requires:
   maas-region:

--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -36,6 +36,7 @@ links:
 
 platforms:
   ubuntu@24.04:amd64:
+  ubuntu@24.04:arm64:
 
 requires:
   maas-db:


### PR DESCRIPTION
- Add `charmcraft.yaml` directive to build for arm64 architecture
- Add observability CI option for releasing the charms for arm64 architecture