### PR TITLE
chore: pin MAAS snap to 3.6/stable

### DIFF
--- a/maas-agent/src/charm.py
+++ b/maas-agent/src/charm.py
@@ -35,7 +35,7 @@ MAAS_RACK_PORTS = [
     ops.Port("tcp", 5248),
     ops.Port("tcp", MAAS_RACK_METRICS_PORT),
 ]
-MAAS_SNAP_CHANNEL = "3.6/candidate"
+MAAS_SNAP_CHANNEL = "3.6/stable"
 
 
 @trace_charm(

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -30,7 +30,7 @@ MAAS_PEER_NAME = "maas-cluster"
 MAAS_API_RELATION = "api"
 MAAS_DB_NAME = "maas-db"
 
-MAAS_SNAP_CHANNEL = "3.6/candidate"
+MAAS_SNAP_CHANNEL = "3.6/stable"
 
 MAAS_PROXY_PORT = 80
 


### PR DESCRIPTION
MAAS 3.6 is officially released. This PR pins the snap version to the stable channel of MAAS snap.