### PR TITLE
fix: pin PostgreSQL revision to the newest succesful one known

### DIFF
--- a/maas-agent/tests/integration/test_charm.py
+++ b/maas-agent/tests/integration/test_charm.py
@@ -59,6 +59,8 @@ async def test_region_integration(ops_test: OpsTest):
             series="noble",
             # workaround for https://bugs.launchpad.net/maas/+bug/2097079
             config={"plugin_audit_enable": False},
+            # workaround for https://bugs.launchpad.net/maas/+bug/2097079, https://github.com/canonical/postgresql-operator/issues/1001
+            revision=758,
             trust=True,
         ),
         ops_test.model.wait_for_idle(

--- a/maas-region/tests/integration/test_charm.py
+++ b/maas-region/tests/integration/test_charm.py
@@ -53,6 +53,8 @@ async def test_database_integration(ops_test: OpsTest):
             trust=True,
             # workaround for https://bugs.launchpad.net/maas/+bug/2097079
             config={"plugin_audit_enable": False},
+            # workaround for https://bugs.launchpad.net/maas/+bug/2097079, https://github.com/canonical/postgresql-operator/issues/1001
+            revision=758,
         ),
         ops_test.model.wait_for_idle(
             apps=["postgresql"], status="active", raise_on_blocked=True, timeout=1000


### PR DESCRIPTION
- Set default revision for PostgreSQL charm during integration tests
- This PostgreSQL charm revision is pinned to the last known successful revision, based on previous GH action runs

Workaround for: https://github.com/canonical/postgresql-operator/issues/1001