### PR TITLE
feat: stop MAAS snap when database is no longer available

### DIFF
--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -51,6 +51,13 @@ class MaasHelper:
             maas.ensure(SnapState.Absent)
 
     @staticmethod
+    def stop() -> None:
+        """Stop snap."""
+        maas = SnapCache()[MAAS_SNAP_NAME]
+        if maas.present:
+            maas.stop()
+
+    @staticmethod
     def get_installed_version() -> Union[str, None]:
         """Get installed version.
 

--- a/maas-region/tests/unit/test_helper.py
+++ b/maas-region/tests/unit/test_helper.py
@@ -47,6 +47,18 @@ class TestHelperSnapCache(unittest.TestCase):
         mock_maas.ensure.assert_not_called()
 
     @patch("helper.SnapCache", autospec=True)
+    def test_stop(self, mock_snap):
+        mock_maas = self._setup_snap(mock_snap, present=True)
+        MaasHelper.stop()
+        mock_maas.stop.assert_called_once()
+
+    @patch("helper.SnapCache", autospec=True)
+    def test_stop_not_present(self, mock_snap):
+        mock_maas = self._setup_snap(mock_snap, present=False)
+        MaasHelper.stop()
+        mock_maas.stop.assert_not_called()
+
+    @patch("helper.SnapCache", autospec=True)
     def test_get_installed_version(self, mock_snap):
         self._setup_snap(mock_snap, present=True, revision="12345")
         self.assertEqual(MaasHelper.get_installed_version(), "12345")


### PR DESCRIPTION
Stop MAAS snap when database relation is broken. By doing so, we can support better the restoration from a backup.