### PR TITLE
fix: s3 relation placeholder

### DIFF
--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -621,7 +621,7 @@ class MaasRegionCharm(ops.CharmBase):
     def _on_s3_parameters_changed(self, event: ops.RelationEvent):
         relation = event.relation
 
-        data = relation.data[relation.app]
+        data = relation.data.get(relation.app, {})
         bucket = data.get("bucket")
         region = data.get("region")
         endpoint = data.get("endpoint")


### PR DESCRIPTION
During relation departure the relation data are not available and an error is thrown. As such s3 relation placeholder should check first if relation data are available.