### PR TITLE
chore: move fqdn to hostname

### DIFF
--- a/maas-agent/lib/charms/maas_region/v0/maas.py
+++ b/maas-agent/lib/charms/maas_region/v0/maas.py
@@ -21,7 +21,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 DEFAULT_ENDPOINT_NAME = "maas-region"
@@ -64,7 +64,7 @@ class MaasRequirerUnitData(MaasDatabag):
     """The schema for the Requirer side of this relation."""
 
     unit: str
-    url: str
+    hostname: str
 
 
 @dataclasses.dataclass
@@ -202,11 +202,11 @@ class MaasRegionRequirer(Object):
         except TypeError:
             return False
 
-    def publish_unit_url(self, url: str) -> None:
-        """Publish unit url in the databag."""
+    def publish_unit_hostname(self, hostname: str) -> None:
+        """Publish unit hostname in the databag."""
         databag_model = MaasRequirerUnitData(
             unit=self._charm.unit.name,
-            url=url,
+            hostname=hostname,
         )
         if relation := self._relation:
             unit_databag = relation.data[self.model.unit]
@@ -274,9 +274,9 @@ class MaasRegionProvider(Object):
             for worker_unit in relation.units:
                 try:
                     worker_data = MaasRequirerUnitData.load(relation.data[worker_unit])  # type: ignore
-                    url = worker_data.url
+                    hostname = worker_data.hostname
                 except TypeError as e:
                     log.debug(f"invalid databag contents: {e}")
                     continue
-                data[url] = worker_unit
+                data[hostname] = worker_unit
         return data

--- a/maas-agent/src/charm.py
+++ b/maas-agent/src/charm.py
@@ -161,14 +161,14 @@ class MaasRackCharm(ops.CharmBase):
 
     def _on_maas_config_received(self, event: maas.MaasConfigReceivedEvent) -> None:
         self.unit.status = ops.MaintenanceStatus("enrolling...")
-        if socket.getfqdn() not in event.config["regions"]:
+        if socket.gethostname() not in event.config["regions"]:
             self._initialize_maas()
             self._setup_network(True)
         else:
             self._setup_network(False)
 
     def _on_maas_created(self, event: ops.RelationCreatedEvent):
-        self.maas_region.publish_unit_url(socket.getfqdn())
+        self.maas_region.publish_unit_hostname(socket.gethostname())
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/maas-agent/tests/unit/test_charm.py
+++ b/maas-agent/tests/unit/test_charm.py
@@ -47,7 +47,7 @@ class TestCharm(unittest.TestCase):
 class TestEnrollment(unittest.TestCase):
     def setUp(self):
         self.remote_app = "maas-region"
-        self.agent_name = socket.getfqdn()
+        self.agent_name = socket.gethostname()
         self.maas_secret = "my_secret"
         self.api_url = "http://region:5240/MAAS"
         self.harness = ops.testing.Harness(MaasRackCharm)

--- a/maas-agent/tests/unit/test_charm.py
+++ b/maas-agent/tests/unit/test_charm.py
@@ -76,7 +76,7 @@ class TestEnrollment(unittest.TestCase):
         rel_id = self.harness.add_relation(maas.DEFAULT_ENDPOINT_NAME, self.remote_app)
         self.assertEqual(
             self.harness.get_relation_data(rel_id, self.harness._unit_name),
-            {"unit": "maas-agent/0", "url": self.agent_name},
+            {"unit": "maas-agent/0", "hostname": self.agent_name},
         )
         mock_helper.setup_rack.assert_not_called()
         # mock enrollment data from region
@@ -90,7 +90,7 @@ class TestEnrollment(unittest.TestCase):
         rel_id = self.harness.add_relation(maas.DEFAULT_ENDPOINT_NAME, self.remote_app)
         self.assertEqual(
             self.harness.get_relation_data(rel_id, self.harness._unit_name),
-            {"unit": "maas-agent/0", "url": self.agent_name},
+            {"unit": "maas-agent/0", "hostname": self.agent_name},
         )
         mock_helper.setup_rack.assert_not_called()
         # mock enrollment data from region

--- a/maas-agent/tests/unit/test_charm.py
+++ b/maas-agent/tests/unit/test_charm.py
@@ -80,7 +80,7 @@ class TestEnrollment(unittest.TestCase):
         )
         mock_helper.setup_rack.assert_not_called()
         # mock enrollment data from region
-        self._enroll(rel_id, ["region.local"])
+        self._enroll(rel_id, ["region-0"])
         mock_helper.setup_rack.assert_called_once_with(self.api_url, self.maas_secret)
         self.assertCountEqual(self.harness.model.unit.opened_ports(), MAAS_RACK_PORTS)
 

--- a/maas-region/lib/charms/maas_region/v0/maas.py
+++ b/maas-region/lib/charms/maas_region/v0/maas.py
@@ -21,7 +21,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 DEFAULT_ENDPOINT_NAME = "maas-region"
@@ -64,7 +64,7 @@ class MaasRequirerUnitData(MaasDatabag):
     """The schema for the Requirer side of this relation."""
 
     unit: str
-    url: str
+    hostname: str
 
 
 @dataclasses.dataclass
@@ -202,11 +202,11 @@ class MaasRegionRequirer(Object):
         except TypeError:
             return False
 
-    def publish_unit_url(self, url: str) -> None:
-        """Publish unit url in the databag."""
+    def publish_unit_hostname(self, hostname: str) -> None:
+        """Publish unit hostname in the databag."""
         databag_model = MaasRequirerUnitData(
             unit=self._charm.unit.name,
-            url=url,
+            hostname=hostname,
         )
         if relation := self._relation:
             unit_databag = relation.data[self.model.unit]
@@ -274,9 +274,9 @@ class MaasRegionProvider(Object):
             for worker_unit in relation.units:
                 try:
                     worker_data = MaasRequirerUnitData.load(relation.data[worker_unit])  # type: ignore
-                    url = worker_data.url
+                    hostname = worker_data.hostname
                 except TypeError as e:
                     log.debug(f"invalid databag contents: {e}")
                     continue
-                data[url] = worker_unit
+                data[hostname] = worker_unit
         return data

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -547,12 +547,16 @@ class MaasRegionCharm(ops.CharmBase):
 
     def _on_list_controllers_action(self, event: ops.ActionEvent):
         """Handle the list-controllers action."""
-        event.set_results({
-            "controllers": json.dumps({
-                "regions": sorted(self._get_regions()),
-                "agents": sorted(list(self.maas_region.gather_rack_units().keys())),
-            }),
-        })
+        event.set_results(
+            {
+                "controllers": json.dumps(
+                    {
+                        "regions": sorted(self._get_regions()),
+                        "agents": sorted(self.maas_region.gather_rack_units().keys()),
+                    }
+                ),
+            }
+        )
 
     def _on_get_api_endpoint_action(self, event: ops.ActionEvent):
         """Handle the get-api-endpoint action."""

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -332,7 +332,7 @@ class MaasRegionCharm(ops.CharmBase):
         return False
 
     def _get_regions(self) -> List[str]:
-        eps = [socket.getfqdn()]
+        eps = [socket.gethostname()]
         if peers := self.peers:
             for u in peers.units:
                 if addr := self.get_peer_data(u, "system-name"):
@@ -547,12 +547,12 @@ class MaasRegionCharm(ops.CharmBase):
 
     def _on_list_controllers_action(self, event: ops.ActionEvent):
         """Handle the list-controllers action."""
-        event.set_results(
-            {
-                "regions": json.dumps(self._get_regions()),
-                "agents": json.dumps(list(self.maas_region.gather_rack_units().keys())),
-            }
-        )
+        event.set_results({
+            "controllers": json.dumps({
+                "regions": sorted(self._get_regions()),
+                "agents": sorted(list(self.maas_region.gather_rack_units().keys())),
+            }),
+        })
 
     def _on_get_api_endpoint_action(self, event: ops.ActionEvent):
         """Handle the get-api-endpoint action."""

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -245,7 +245,7 @@ class MaasRegionCharm(ops.CharmBase):
         Returns:
             str: either `region` of `region+rack`
         """
-        has_agent = self.maas_region.gather_rack_units().get(socket.getfqdn())
+        has_agent = self.maas_region.gather_rack_units().get(socket.gethostname())
         return "region+rack" if has_agent else "region"
 
     def set_peer_data(
@@ -491,7 +491,7 @@ class MaasRegionCharm(ops.CharmBase):
 
     def _on_maas_peer_changed(self, event: ops.RelationEvent) -> None:
         logger.info(event)
-        self.set_peer_data(self.unit, "system-name", socket.getfqdn())
+        self.set_peer_data(self.unit, "system-name", socket.gethostname())
         if self.unit.is_leader():
             self._publish_tokens()
 

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -513,20 +513,20 @@ class TestCharmActions(unittest.TestCase):
         )
         self.harness.add_relation_unit(rel_id, "maas-region/1")
         self.harness.update_relation_data(
-            rel_id, "maas-region/1", {"system-name": json.dumps("other.host.local")}
+            rel_id, "maas-region/1", {"system-name": json.dumps("other-host")}
         )
         self.harness.add_relation(
             maas.DEFAULT_ENDPOINT_NAME,
             "maas-agent",
-            unit_data={"unit": "maas-agent/0", "hostname": "agent.local"},
+            unit_data={"unit": "maas-agent/0", "hostname": "agent-0"},
         )
         self.harness.begin()
         output = self.harness.run_action("list-controllers")
         self.assertEqual(
             json.loads(output.results["controllers"]),
             {
-                "regions": sorted([socket.gethostname(), "other.host.local"]),
-                "agents": ["agent.local"],
+                "regions": sorted([socket.gethostname(), "other-host"]),
+                "agents": ["agent-0"],
             },
         )
 

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -499,12 +499,17 @@ class TestCharmActions(unittest.TestCase):
         self.harness.set_leader(True)
         self.harness.begin()
         output = self.harness.run_action("list-controllers")
-        self.assertEqual(json.loads(output.results["controllers"]), {"regions": [socket.gethostname()], "agents": []})
+        self.assertEqual(
+            json.loads(output.results["controllers"]),
+            {"regions": [socket.gethostname()], "agents": []},
+        )
 
     def test_list_controllers_action_complex(self):
         self.harness.set_leader(True)
         rel_id = self.harness.add_relation(
-            MAAS_PEER_NAME, "maas-region", unit_data={"system-name": json.dumps(socket.gethostname())}
+            MAAS_PEER_NAME,
+            "maas-region",
+            unit_data={"system-name": json.dumps(socket.gethostname())},
         )
         self.harness.add_relation_unit(rel_id, "maas-region/1")
         self.harness.update_relation_data(
@@ -518,7 +523,11 @@ class TestCharmActions(unittest.TestCase):
         self.harness.begin()
         output = self.harness.run_action("list-controllers")
         self.assertEqual(
-            json.loads(output.results["controllers"]), {"regions": sorted([socket.gethostname(), "other.host.local"]), "agents": ["agent.local"]}
+            json.loads(output.results["controllers"]),
+            {
+                "regions": sorted([socket.gethostname(), "other.host.local"]),
+                "agents": ["agent.local"],
+            },
         )
 
     def test_create_backup_action(self) -> None:

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -283,12 +283,12 @@ class TestClusterUpdates(unittest.TestCase):
         rel_id = self.harness.add_relation(
             maas.DEFAULT_ENDPOINT_NAME,
             remote_app,
-            unit_data={"unit": f"{remote_app}/0", "url": "some_url"},
+            unit_data={"unit": f"{remote_app}/0", "hostname": "some_hostname"},
         )
         mock_helper.setup_region.assert_not_called()
         data = self.harness.get_relation_data(rel_id, "maas-region")
         self.assertEqual(data["api_url"], "http://10.0.0.10:5240/MAAS")
-        self.assertEqual(data["regions"], f'["{socket.getfqdn()}"]')
+        self.assertEqual(data["regions"], f'["{socket.gethostname()}"]')
         self.assertIn("maas_secret_id", data)  # codespell:ignore
 
     @patch("charm.MaasHelper", autospec=True)
@@ -302,7 +302,7 @@ class TestClusterUpdates(unittest.TestCase):
         self.harness.add_relation(
             maas.DEFAULT_ENDPOINT_NAME,
             remote_app,
-            unit_data={"unit": f"{remote_app}/0", "url": "some_url"},
+            unit_data={"unit": f"{remote_app}/0", "hostname": "some_hostname"},
         )
         mock_helper.set_prometheus_metrics.assert_called_with(
             "maas-admin-internal", "10.0.0.10", True
@@ -335,14 +335,14 @@ class TestClusterUpdates(unittest.TestCase):
     def test_on_maas_cluster_changed_new_agent_same_machine(self, mock_helper, _mock_conn_id):
         mock_helper.get_maas_mode.return_value = "region"
         mock_helper.get_maas_secret.return_value = "very-secret"
-        my_fqdn = socket.getfqdn()
+        my_hostname = socket.gethostname()
         self.harness.set_leader(True)
         self.harness.begin()
         remote_app = "maas-agent"
         self.harness.add_relation(
             maas.DEFAULT_ENDPOINT_NAME,
             remote_app,
-            unit_data={"unit": f"{remote_app}/0", "url": my_fqdn},
+            unit_data={"unit": f"{remote_app}/0", "hostname": my_hostname},
         )
         mock_helper.setup_region.assert_called_once_with(
             f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS",
@@ -359,7 +359,7 @@ class TestClusterUpdates(unittest.TestCase):
         rel_id = self.harness.add_relation(
             maas.DEFAULT_ENDPOINT_NAME,
             remote_app,
-            unit_data={"unit": f"{remote_app}/0", "url": "some_url"},
+            unit_data={"unit": f"{remote_app}/0", "hostname": "some_hostname"},
         )
         self.harness.begin()
         self.harness.remove_relation_unit(rel_id, f"{remote_app}/0")
@@ -373,13 +373,13 @@ class TestClusterUpdates(unittest.TestCase):
     def test_on_maas_cluster_changed_remove_agent_same_machine(self, mock_helper, _mock_conn_id):
         mock_helper.get_maas_mode.return_value = "region+rack"
         mock_helper.get_maas_secret.return_value = "very-secret"
-        my_fqdn = socket.getfqdn()
+        my_hostname = socket.gethostname()
         self.harness.set_leader(True)
         remote_app = "maas-agent"
         rel_id = self.harness.add_relation(
             maas.DEFAULT_ENDPOINT_NAME,
             remote_app,
-            unit_data={"unit": f"{remote_app}/0", "url": my_fqdn},
+            unit_data={"unit": f"{remote_app}/0", "hostname": my_hostname},
         )
         self.harness.begin()
         self.harness.remove_relation_unit(rel_id, f"{remote_app}/0")
@@ -499,13 +499,12 @@ class TestCharmActions(unittest.TestCase):
         self.harness.set_leader(True)
         self.harness.begin()
         output = self.harness.run_action("list-controllers")
-        self.assertEqual(json.loads(output.results["regions"]), [socket.getfqdn()])
-        self.assertEqual(json.loads(output.results["agents"]), [])
+        self.assertEqual(json.loads(output.results["controllers"]), {"regions": [socket.gethostname()], "agents": []})
 
     def test_list_controllers_action_complex(self):
         self.harness.set_leader(True)
         rel_id = self.harness.add_relation(
-            MAAS_PEER_NAME, "maas-region", unit_data={"system-name": json.dumps(socket.getfqdn())}
+            MAAS_PEER_NAME, "maas-region", unit_data={"system-name": json.dumps(socket.gethostname())}
         )
         self.harness.add_relation_unit(rel_id, "maas-region/1")
         self.harness.update_relation_data(
@@ -514,14 +513,13 @@ class TestCharmActions(unittest.TestCase):
         self.harness.add_relation(
             maas.DEFAULT_ENDPOINT_NAME,
             "maas-agent",
-            unit_data={"unit": "maas-agent/0", "url": "agent.local"},
+            unit_data={"unit": "maas-agent/0", "hostname": "agent.local"},
         )
         self.harness.begin()
         output = self.harness.run_action("list-controllers")
-        self.assertCountEqual(
-            json.loads(output.results["regions"]), [socket.getfqdn(), "other.host.local"]
+        self.assertEqual(
+            json.loads(output.results["controllers"]), {"regions": sorted([socket.gethostname(), "other.host.local"]), "agents": ["agent.local"]}
         )
-        self.assertCountEqual(json.loads(output.results["agents"]), ["agent.local"])
 
     def test_create_backup_action(self) -> None:
         self.harness.set_leader(True)


### PR DESCRIPTION
- Replace fqdn tracking with hostname tracking for maas-region and maas-agent units in the relation databags
- Alter the output of list-controllers action so that it contains a single result output key that can be json loaded with one step