### PR TITLE
feat: restore backup action

### DIFF
--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -95,6 +95,9 @@ actions:
       controller-id:
         type: string
         description: The controller id to assign to this region. See `list-backup` for a list of controller ids
+    required:
+      - backup-id
+      - controller-id
   list-backups:
     description: List available MAAS backups
       NOTE - This is a noop action, and serves only as a placeholder

--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -92,6 +92,9 @@ actions:
       backup-id:
         type: string
         description: The id of the backup to restore from. See `list-backup` for a list of backup ids
+      controller-id:
+        type: string
+        description: The controller id to assign to this region. See `list-backup` for a list of controller ids
   list-backups:
     description: List available MAAS backups
       NOTE - This is a noop action, and serves only as a placeholder

--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -86,9 +86,8 @@ actions:
     description: Get MAAS API URL
   create-backup:
     description: Create a backup of MAAS data not stored in the database.
-  restore-from-backup:
+  restore-backup:
     description: Restore from a MAAS backup
-      NOTE - This is a noop action, and serves only as a placeholder
     params:
       backup-id:
         type: string

--- a/maas-region/src/backups.py
+++ b/maas-region/src/backups.py
@@ -589,7 +589,7 @@ Juju Version: {self.charm.model.juju_version!s}
             with tarfile.open(fileobj=f, mode="w:gz") as tar:
                 tar.add(
                     SNAP_PATH_TO_IMAGES,
-                    arcname=Path(IMAGE_TAR_FILENAME).stem,
+                    arcname="",
                 )
             f.flush()
             event.log("Uploading image archive to S3, see debug-log for progress...")
@@ -607,7 +607,7 @@ Juju Version: {self.charm.model.juju_version!s}
             with tarfile.open(fileobj=f, mode="w:gz") as tar:
                 tar.add(
                     SNAP_PATH_TO_PRESEEDS,
-                    arcname=Path(PRESEED_TAR_FILENAME).stem,
+                    arcname="",
                 )
             f.flush()
             event.log("Uploading preseed archive to S3...")
@@ -897,7 +897,7 @@ Juju Version: {self.charm.model.juju_version!s}
         local_path: Path,
         file_type: str | None = None,
     ) -> bool:
-        file_type = file_type or Path(s3_path).stem
+        file_type = file_type or self._pathname(s3_path)
 
         # Clean before restore
         shutil.rmtree(local_path, ignore_errors=True)
@@ -982,7 +982,7 @@ Juju Version: {self.charm.model.juju_version!s}
                     s3_path,
                     tmp_path,
                     Callback=DownloadProgressPercentage(
-                        f.name, log_label=file_type or Path(s3_path).stem, size=size
+                        f.name, log_label=file_type or self._pathname(s3_path), size=size
                     ),
                 )
 
@@ -1020,6 +1020,9 @@ Juju Version: {self.charm.model.juju_version!s}
                 os.unlink(tmp_path)
 
         return None
+
+    def _pathname(self, pathname: str) -> str:
+        return Path(pathname).name.split(".")[0]
 
     def _pre_restore_checks(self, event: ActionEvent) -> bool:
         """Run some checks before starting the restore.

--- a/maas-region/src/backups.py
+++ b/maas-region/src/backups.py
@@ -842,7 +842,7 @@ Juju Version: {self.charm.model.juju_version!s}
 
                     event.log(f"Extracting from {file_type}...")
                     with tarfile.open(fileobj=f, mode="r:gz") as tar:
-                        tar.extractall(path="/")
+                        tar.extractall(path=local_path)
 
                 # check the storage path exists and contains something
                 if local_path.exists() and any(local_path.iterdir()):

--- a/maas-region/src/backups.py
+++ b/maas-region/src/backups.py
@@ -653,19 +653,10 @@ Juju Version: {self.charm.model.juju_version!s}
             event.fail(error_message)
             return
 
-        relation = self.model.get_relation(MAAS_REGION_RELATION)
-        if relation is None:
-            error_message = "Failed to fetch MAAS-region relation"
-            logger.error(f"Restore failed: {error_message}")
-            event.fail(error_message)
-            return
-
         self.charm.unit.status = MaintenanceStatus("Restoring from backup...")
-        relation.data[self.model.app][f"{self.model.unit.name}_restore"] = json.dumps("Restoring")
 
         self._run_restore(event, s3_parameters, backup_id)
 
-        relation.data[self.model.app][f"{self.model.unit.name}_restore"] = ""
         self.charm.unit.status = ActiveStatus()
         event.set_results({"restore-status": "restore finished"})
 

--- a/maas-region/src/backups.py
+++ b/maas-region/src/backups.py
@@ -819,7 +819,8 @@ Juju Version: {self.charm.model.juju_version!s}
             )
             return False
 
-        regions = relation.units
+        # the relation only includes remote units, and does not include the local unit
+        regions = relation.units.union({self.model.unit})
 
         if len(controllers) != len(regions):
             self._log_error(

--- a/maas-region/src/backups.py
+++ b/maas-region/src/backups.py
@@ -74,14 +74,17 @@ class ProgressPercentage:
 
     def __call__(self, bytes_amount: int):
         """Track the progress of the upload as a callback."""
+        verb, direction = ("uploading", "to") if self._uploading else ("downloading", "from")
+
+        if self._size <= 0:
+            logger.info(f"{verb} {self._log_label} {direction} s3: {100:.2f}% (empty file)")
+            return
+
         with self._lock:
             self._seen_so_far += bytes_amount
             percentage = (self._seen_so_far / self._size) * 100
             if (percentage - self._last_percentage) >= self._update_interval or percentage >= 100:
                 self._last_percentage = percentage
-                verb, direction = (
-                    ("uploading", "to") if self._uploading else ("downloading", "from")
-                )
                 logger.info(f"{verb} {self._log_label} {direction} s3: {percentage:.2f}%")
 
 

--- a/maas-region/src/backups.py
+++ b/maas-region/src/backups.py
@@ -748,7 +748,12 @@ Juju Version: {self.charm.model.juju_version!s}
 
                 with tempfile.NamedTemporaryFile(suffix=".tar.gz") as f:
                     event.log("Downloading image archive from S3...")
-                    client.download_file(bucket, f.name, path)
+                    client.download_file(
+                        bucket,
+                        f.name,
+                        path,
+                        Callback=ProgressPercentage(f.name, "image archive"),
+                    )
 
                     event.log("Extracting images from image archive...")
                     with tarfile.open(fileobj=f, mode="r:gz") as tar:

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -186,21 +186,6 @@ class MaasRegionCharm(ops.CharmBase):
         return f"postgres://{username}:{password}@{endpoints}/{self.maasdb_name}"
 
     @property
-    def restore_running(self) -> bool:
-        """Reports the completion status of the backup restore action.
-
-        Returns:
-            bool: True if all units have restored
-        """
-        if relation := self.model.get_relation(MAAS_PEER_NAME):
-            return any(
-                self.get_peer_data(relation.app, f"{unit.name}_restore") == "Restoring"
-                for unit in relation.units
-            )
-
-        return False
-
-    @property
     def version(self) -> str | None:
         """Reports the current workload version.
 
@@ -464,8 +449,6 @@ class MaasRegionCharm(ops.CharmBase):
             e.add_status(ops.WaitingStatus("Waiting for database DSN"))
         elif not self.maas_api_url:
             ops.WaitingStatus("Waiting for MAAS initialization")
-        elif self.restore_running:
-            ops.WaitingStatus("Waiting for restore to complete")
         else:
             self.unit.status = ops.ActiveStatus()
 

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -505,8 +505,20 @@ class MaasRegionCharm(ops.CharmBase):
     def _on_maas_cluster_changed(self, event: ops.RelationEvent) -> None:
         logger.info(event)
         # Handle data updates
-        if region_id := self.get_peer_data(self.app, f"{self.unit.name}_id"):
+        if region_id := self.get_peer_data(self.app, f"{self.unit.name}_restore_id"):
             (Path(MAAS_SNAP_COMMON) / "maas_id").write_text(f"{region_id}\n")
+            self.set_peer_data(self.app, f"{self.unit.name}_restore_id", "")
+
+        if restore_data := self.get_peer_data(self.app, f"{self.unit.name}_restore_data"):
+            self.unit.status = ops.MaintenanceStatus("Restoring from backup...")
+            self.set_peer_data(self.app, f"{self.unit.name}_restore_data", "")
+            self.backup._run_restore_unit(
+                event=ops.ActionEvent(event.handle),
+                s3_parameters=restore_data["s3_parameters"],
+                backup_id=restore_data["backup_id"],
+            )
+            self.unit.status = ops.ActiveStatus()
+            return
 
         # Handle cluster joining
         if self.unit.is_leader() and not self._publish_tokens():

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -10,7 +10,6 @@ import random
 import socket
 import string
 import subprocess
-from pathlib import Path
 from typing import Any
 
 import ops
@@ -63,8 +62,6 @@ MAAS_REGION_PORTS = [
 
 MAAS_ADMIN_SECRET_LABEL = "maas-admin"
 MAAS_ADMIN_SECRET_KEY = "maas-admin-secret-uri"
-
-MAAS_SNAP_COMMON = "/var/snap/maas/common/maas"
 
 MAAS_BACKUP_TYPES = ["full", "differential", "incremental"]
 
@@ -504,21 +501,6 @@ class MaasRegionCharm(ops.CharmBase):
 
     def _on_maas_cluster_changed(self, event: ops.RelationEvent) -> None:
         logger.info(event)
-        # Handle data updates
-        if region_id := self.get_peer_data(self.app, f"{self.unit.name}_restore_id"):
-            (Path(MAAS_SNAP_COMMON) / "maas_id").write_text(f"{region_id}\n")
-            self.set_peer_data(self.app, f"{self.unit.name}_restore_id", "")
-
-        if restore_data := self.get_peer_data(self.app, f"{self.unit.name}_restore_data"):
-            self.unit.status = ops.MaintenanceStatus("Restoring from backup...")
-            self.set_peer_data(self.app, f"{self.unit.name}_restore_data", "")
-            self.backup._run_restore_unit(
-                event=ops.ActionEvent(event.handle),
-                s3_parameters=restore_data["s3_parameters"],
-                backup_id=restore_data["backup_id"],
-            )
-            self.unit.status = ops.ActiveStatus()
-            return
 
         # Handle cluster joining
         if self.unit.is_leader() and not self._publish_tokens():

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -10,6 +10,7 @@ import random
 import socket
 import string
 import subprocess
+from pathlib import Path
 from typing import Any
 
 import ops
@@ -62,6 +63,8 @@ MAAS_REGION_PORTS = [
 
 MAAS_ADMIN_SECRET_LABEL = "maas-admin"
 MAAS_ADMIN_SECRET_KEY = "maas-admin-secret-uri"
+
+MAAS_SNAP_COMMON = "/var/snap/maas/common/maas"
 
 MAAS_BACKUP_TYPES = ["full", "differential", "incremental"]
 
@@ -501,6 +504,11 @@ class MaasRegionCharm(ops.CharmBase):
 
     def _on_maas_cluster_changed(self, event: ops.RelationEvent) -> None:
         logger.info(event)
+        # Handle data updates
+        if region_id := self.get_peer_data(self.app, f"{self.unit.name}_id"):
+            (Path(MAAS_SNAP_COMMON) / "maas_id").write_text(f"{region_id}\n")
+
+        # Handle cluster joining
         if self.unit.is_leader() and not self._publish_tokens():
             event.defer()
             return

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -186,6 +186,21 @@ class MaasRegionCharm(ops.CharmBase):
         return f"postgres://{username}:{password}@{endpoints}/{self.maasdb_name}"
 
     @property
+    def restore_running(self) -> bool:
+        """Reports the completion status of the backup restore action.
+
+        Returns:
+            bool: True if all units have restored
+        """
+        if relation := self.model.get_relation(MAAS_PEER_NAME):
+            return any(
+                self.get_peer_data(relation.app, f"{unit.name}_restore") == "Restoring"
+                for unit in relation.units
+            )
+
+        return False
+
+    @property
     def version(self) -> str | None:
         """Reports the current workload version.
 
@@ -449,6 +464,8 @@ class MaasRegionCharm(ops.CharmBase):
             e.add_status(ops.WaitingStatus("Waiting for database DSN"))
         elif not self.maas_api_url:
             ops.WaitingStatus("Waiting for MAAS initialization")
+        elif self.restore_running:
+            ops.WaitingStatus("Waiting for restore to complete")
         else:
             self.unit.status = ops.ActiveStatus()
 

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -501,8 +501,6 @@ class MaasRegionCharm(ops.CharmBase):
 
     def _on_maas_cluster_changed(self, event: ops.RelationEvent) -> None:
         logger.info(event)
-
-        # Handle cluster joining
         if self.unit.is_leader() and not self._publish_tokens():
             event.defer()
             return

--- a/maas-region/tests/unit/test_backup.py
+++ b/maas-region/tests/unit/test_backup.py
@@ -1023,7 +1023,9 @@ class TestProgressPercentage(unittest.TestCase):
         _getsize.return_value = 50
 
         # Test creation and initial call
-        progress_percentage = ProgressPercentage("test-file", "test-label", update_interval=10)
+        progress_percentage = ProgressPercentage(
+            "test-file", "test-label", update_interval=10, uploading=True
+        )
         progress_percentage(25)
         self.assertEqual(progress_percentage._last_percentage, 50)
         logger.info.assert_called_once_with("uploading test-label to s3: 50.00%")

--- a/maas-region/tests/unit/test_backup.py
+++ b/maas-region/tests/unit/test_backup.py
@@ -15,9 +15,9 @@ from botocore.exceptions import BotoCoreError, ClientError, ConnectTimeoutError,
 
 from backups import (
     FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE,
-    UploadProgressPercentage,
     DownloadProgressPercentage,
     RegionsNotAvailableError,
+    UploadProgressPercentage,
 )
 from charm import MaasRegionCharm
 
@@ -1024,7 +1024,9 @@ class TestProgressPercentage(unittest.TestCase):
         _getsize.return_value = 50
 
         # Test creation and initial call
-        progress_percentage = UploadProgressPercentage("test-file", "test-label", update_interval=10)
+        progress_percentage = UploadProgressPercentage(
+            "test-file", "test-label", update_interval=10
+        )
         progress_percentage(25)
         self.assertEqual(progress_percentage._last_percentage, 50)
         logger.info.assert_called_once_with("uploading test-label to s3: 50.00%")
@@ -1049,9 +1051,10 @@ class TestProgressPercentage(unittest.TestCase):
 
     @patch("backups.logger", spec=logging.Logger)
     def test_download_progress_percentage(self, logger):
-
         # Test creation and initial call
-        progress_percentage = DownloadProgressPercentage("test-file", "test-label", size=50, update_interval=10)
+        progress_percentage = DownloadProgressPercentage(
+            "test-file", "test-label", size=50, update_interval=10
+        )
         progress_percentage(25)
         self.assertEqual(progress_percentage._last_percentage, 50)
         logger.info.assert_called_once_with("downloading test-label from s3: 50.00%")

--- a/maas-region/tests/unit/test_backup.py
+++ b/maas-region/tests/unit/test_backup.py
@@ -15,7 +15,8 @@ from botocore.exceptions import BotoCoreError, ClientError, ConnectTimeoutError,
 
 from backups import (
     FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE,
-    ProgressPercentage,
+    UploadProgressPercentage,
+    DownloadProgressPercentage,
     RegionsNotAvailableError,
 )
 from charm import MaasRegionCharm
@@ -1019,13 +1020,11 @@ backup-id            | action              | status   | backup-path
 class TestProgressPercentage(unittest.TestCase):
     @patch("backups.logger", spec=logging.Logger)
     @patch("backups.os.path.getsize")
-    def test_progress_percentage(self, _getsize, logger):
+    def test_upload_progress_percentage(self, _getsize, logger):
         _getsize.return_value = 50
 
         # Test creation and initial call
-        progress_percentage = ProgressPercentage(
-            "test-file", "test-label", update_interval=10, uploading=True
-        )
+        progress_percentage = UploadProgressPercentage("test-file", "test-label", update_interval=10)
         progress_percentage(25)
         self.assertEqual(progress_percentage._last_percentage, 50)
         logger.info.assert_called_once_with("uploading test-label to s3: 50.00%")
@@ -1047,3 +1046,30 @@ class TestProgressPercentage(unittest.TestCase):
         progress_percentage(25)
         self.assertEqual(progress_percentage._last_percentage, 150)
         logger.info.assert_called_once_with("uploading test-label to s3: 150.00%")
+
+    @patch("backups.logger", spec=logging.Logger)
+    def test_download_progress_percentage(self, logger):
+
+        # Test creation and initial call
+        progress_percentage = DownloadProgressPercentage("test-file", "test-label", size=50, update_interval=10)
+        progress_percentage(25)
+        self.assertEqual(progress_percentage._last_percentage, 50)
+        logger.info.assert_called_once_with("downloading test-label from s3: 50.00%")
+
+        # Test less than update interval
+        logger.reset_mock()
+        progress_percentage(1)
+        self.assertEqual(progress_percentage._last_percentage, 50)
+        logger.info.assert_not_called()
+
+        # Test cumulative progress greater than update interval
+        logger.reset_mock()
+        progress_percentage(24)
+        self.assertEqual(progress_percentage._last_percentage, 100)
+        logger.info.assert_called_once_with("downloading test-label from s3: 100.00%")
+
+        # Test over 100% - unlikely but possible!
+        logger.reset_mock()
+        progress_percentage(25)
+        self.assertEqual(progress_percentage._last_percentage, 150)
+        logger.info.assert_called_once_with("downloading test-label from s3: 150.00%")


### PR DESCRIPTION
Add `restore-backup` action to the region charm.

Assumes the file structure created by #520 and #525  exists on S3

To restore from a backup, the user will need to execute the action on all region charms in the cluster:
```
juju run maas-region/0 restore-backup backup-id="..."
juju run maas-region/1 restore-backup backup-id="..."
juju run maas-region/2 restore-backup backup-id="..."
```