### PR TITLE
chore: pin setuptool to <80.9.0

### DIFF
--- a/maas-agent/requirements.txt
+++ b/maas-agent/requirements.txt
@@ -2,4 +2,7 @@ ops ~=3.1
 # for grafana agent
 pydantic < 2
 cosl
+
+# For tracing
 opentelemetry-exporter-otlp-proto-http>=1.21.0
+setuptools<80.9.0

--- a/maas-region/requirements.txt
+++ b/maas-region/requirements.txt
@@ -7,4 +7,7 @@ botocore >=1.39.10, <1.40.0
 # For Grafana agent
 pydantic < 2
 cosl
+
+# For tracing
 opentelemetry-exporter-otlp-proto-http>=1.21.0
+setuptools<80.9.0

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   ],
   "ignoreDeps": [
     "canonical/observability",
-    "tj-actions/changed-files"
+    "tj-actions/changed-files",
+    "setuptools"
   ]
 }


### PR DESCRIPTION
This is required since the charms are depending on `opentelemetry-exporter-otlp-proto-http` for charm tracing. This one has a dependency on `googleapis-common-protos`, this one has a dependency on `protobuf` and the last one has a dependency on `setuptools`. The last one, on version `80.9.0`, added a deprecation warning that is flooding the charm log output:

```bash
unit-maas-region-1: 14:02:17 WARNING unit.maas-region/1.leader-settings-changed /var/lib/juju/agents/unit-maas-region-1/charm/venv/google/__init__.py:2: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
unit-maas-region-1: 14:02:17 WARNING unit.maas-region/1.leader-settings-changed   __import__('pkg_resources').declare_namespace(__name__)
```