### PR TITLE
chore(deps): update dependencies boto3 and botocore

### DIFF
--- a/maas-region/requirements.txt
+++ b/maas-region/requirements.txt
@@ -1,8 +1,10 @@
 ops ~=3.1
 
 # For backup support
-boto3 >= 1.39.10, <1.40.0
-botocore >=1.39.10, <1.40.0
+# Botocore and boto3 are updated frequently, so an upper bound is required to allow
+# the latest point release to be installed without the need for many charm releases.
+boto3 >=1.40.12, <1.41.0
+botocore >=1.40.12, <1.41.0
 
 # For Grafana agent
 pydantic < 2

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,11 @@
   "ignoreDeps": [
     "canonical/observability",
     "tj-actions/changed-files"
+  ],
+  "packageRules": [
+    {
+      "description": "Update botocore and boto3 together",
+      "matchPackageNames": ["botocore", "boto3"]
+    }
   ]
 }


### PR DESCRIPTION
- Boto3 releases are released pretty much daily (see [here](https://pypi.org/project/boto3/#history)). 
- To avoid daily releases of the charm, we have a range set in requirements.txt. If a new release is a minor release, renovate will trigger a new PR so that our CI will be triggered. Right now we don't have integration tests involving boto3 and botocore but this will be relevant in future. 
- Try to combine future PRs of boto3 and botocore to allow our CI to pass next time they are triggered.