### PR TITLE
feat: collect extra metrics

### DIFF
--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -15,7 +15,7 @@ from typing import Any
 import ops
 import yaml
 from charms.data_platform_libs.v0 import data_interfaces as db
-from charms.grafana_agent.v0 import _MetricsEndpointDict, cos_agent
+from charms.grafana_agent.v0 import cos_agent
 from charms.maas_site_manager_k8s.v0 import enroll
 from charms.operator_libs_linux.v2.snap import SnapError
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
@@ -141,7 +141,7 @@ class MaasRegionCharm(ops.CharmBase):
         self.framework.observe(api_events.relation_broken, self._on_api_endpoint_changed)
 
         # COS
-        endpoints: list[_MetricsEndpointDict] = [
+        endpoints: list[cos_agent._MetricsEndpointDict] = [
             {"path": "/metrics", "port": MAAS_REGION_METRICS_PORT},
             {"path": "/MAAS/metrics", "port": MAAS_CLUSTER_METRICS_PORT},
             {"path": "/metrics/temporal", "port": MAAS_HTTP_PORT},


### PR DESCRIPTION
Resolves https://github.com/canonical/maas-charms/issues/322

## QA
- The agent port 5248 is not open when running in region mode, but is when `enable_rack_mode=true` is set i.e. in region+rack. Verified using `juju status`. 
- The grafana agent config now contains the temporal endpoint, in addition to the agent metrics endpoint when rack mode is toggled: 
```bash
ubuntu@juju-7e202d-1:~$ sudo cat /etc/grafana-agent.yaml  # run on the region machine
...

- job_name: maas-region_2_default
      metrics_path: /metrics/temporal
      static_configs:
      - labels:
          juju_application: maas-region
          juju_model: maas
          juju_model_uuid: 3ef4d822-ab19-4ac8-838a-ccd4497e202d
          juju_unit: maas-region/0
        targets:
        - localhost:5240
 ...
 # and then only when enable_rack_mode=true : 
 
 - job_name: maas-region_3_default
      metrics_path: /metrics/agent
      static_configs:
      - labels:
          juju_application: maas-region
          juju_model: maas
          juju_model_uuid: 3ef4d822-ab19-4ac8-838a-ccd4497e202d
          juju_unit: maas-region/0
        targets:
        - localhost:5248

```
- The temporal endpoints are now available to view in both modes: 
<img width="1110" height="497" alt="image" src="https://github.com/user-attachments/assets/5c8a2116-c0d7-4322-9e91-17a11105171e" />
- The maas.agent logs are only available in the region+rack mode 
<img width="2037" height="1301" alt="image" src="https://github.com/user-attachments/assets/18693181-712a-479c-81bf-14d67bf97c65" />

