### PR TITLE
feat: add get-maas-secret action

### DIFF
--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -80,6 +80,8 @@ actions:
         description: Username for the new account.
   get-api-endpoint:
     description: Get MAAS API URL
+  get-maas-secret:
+    description: Get MAAS secret
   create-backup:
     description: Create a backup of MAAS data not stored in the database.
   restore-backup:

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -73,7 +73,7 @@ MAAS_RACK_PORTS = [
     ops.Port("tcp", 5240),  # nginx primary
     *[ops.Port("tcp", p) for p in range(5241, 5247 + 1)],  # Internal services
     ops.Port("tcp", MAAS_RACK_METRICS_PORT),
-    ops.Port("tcp", MAAS_AGENT_METRICS_PORT)
+    ops.Port("tcp", MAAS_AGENT_METRICS_PORT),
 ]
 MAAS_REGION_RACK_PORTS = list(set(MAAS_REGION_PORTS).union(MAAS_RACK_PORTS))
 
@@ -167,6 +167,7 @@ class MaasRegionCharm(ops.CharmBase):
         self.framework.observe(self.on.create_admin_action, self._on_create_admin_action)
         self.framework.observe(self.on.get_api_key_action, self._on_get_api_key_action)
         self.framework.observe(self.on.get_api_endpoint_action, self._on_get_api_endpoint_action)
+        self.framework.observe(self.on.get_maas_secret_action, self._on_get_maas_secret_action)
 
         # Charm configuration
         self.framework.observe(self.on.config_changed, self._on_config_changed)
@@ -527,6 +528,13 @@ class MaasRegionCharm(ops.CharmBase):
         """Handle the get-api-endpoint action."""
         if url := self.maas_api_url:
             event.set_results({"api-url": url})
+        else:
+            event.fail("MAAS is not initialized yet")
+
+    def _on_get_maas_secret_action(self, event: ops.ActionEvent):
+        """Handle the get-maas-secret action."""
+        if secret := MaasHelper.get_maas_secret():
+            event.set_results({"maas-secret": secret})
         else:
             event.fail("MAAS is not initialized yet")
 

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -436,6 +436,22 @@ class TestCharmActions(unittest.TestCase):
         output = self.harness.run_action("get-api-endpoint")
         self.assertEqual(output.results["api-url"], "http://10.0.0.10:5240/MAAS")
 
+    @patch("charm.MaasHelper", autospec=True)
+    def test_get_maas_secret_action(self, mock_helper):
+        self.harness.set_leader(True)
+        self.harness.begin()
+        mock_helper.get_maas_secret.return_value = "0123456789ab0123456789"
+        output = self.harness.run_action("get-maas-secret")
+        self.assertEqual(output.results["maas-secret"], "0123456789ab0123456789")
+
+    def test_get_maas_secret_action_fail(self):
+        self.harness.set_leader(True)
+        self.harness.begin()
+        with self.assertRaises(ops.testing.ActionFailed) as e:
+            self.harness.run_action("get-maas-secret")
+        err = e.exception
+        self.assertEqual(err.message, "MAAS is not initialized yet")
+
     @patch(
         "charm.MaasRegionCharm.bind_address",
         new_callable=PropertyMock(return_value="10.0.0.10"),

--- a/maas-region/tests/unit/test_helper.py
+++ b/maas-region/tests/unit/test_helper.py
@@ -128,6 +128,16 @@ class TestHelperFiles(unittest.TestCase):
     def test_is_tls_enabled_not_initalized(self, _):
         self.assertEqual(MaasHelper.is_tls_enabled(), None)
 
+    @patch(
+        "pathlib.Path.open", new_callable=lambda: mock_open(read_data="0123456789ab0123456789\n")
+    )
+    def test_get_maas_secret(self, _):
+        self.assertEqual(MaasHelper.get_maas_secret(), "0123456789ab0123456789")
+
+    @patch("pathlib.Path.open", side_effect=OSError)
+    def test_get_maas_secret_not_initialised(self, _):
+        self.assertIsNone(MaasHelper.get_maas_secret())
+
 
 class TestHelperSetup(unittest.TestCase):
     @patch("helper.subprocess.check_call")


### PR DESCRIPTION
Add an action to get MAAS secret. This is useful to join non-charmed MAAS rack agents to charmed MAAS region cluster.