### PR TITLE
chore: Upgrade to 3.7

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       any_changed: ${{ steps.echo-changes.outputs.any_changed }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Determine changed files in the commit

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -24,7 +24,7 @@ jobs:
       open_prs: ${{ steps.open-prs.outputs.open_prs }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -31,7 +31,7 @@ MAAS_PEER_NAME = "maas-cluster"
 MAAS_API_RELATION = "api"
 MAAS_DB_NAME = "maas-db"
 
-MAAS_SNAP_CHANNEL = "3.6/stable"
+MAAS_SNAP_CHANNEL = "3.7/stable"
 
 MAAS_PROXY_PORT = 80
 

--- a/maas-region/tests/integration/test_charm.py
+++ b/maas-region/tests/integration/test_charm.py
@@ -42,7 +42,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 async def test_charm_version_is_set(ops_test: OpsTest):
     status = await ops_test.model.get_status()
     version = status.applications[APP_NAME].workload_version
-    assert version.startswith("3.6.")
+    assert version.startswith("3.7.")
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
Updated snap channel to 3.7/stable, and updated ancillary job definitions and files where necessary.