### PR TITLE
fix: proper group botocore packages into single PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
   "packageRules": [
     {
       "description": "Update botocore and boto3 together",
-      "matchPackageNames": ["botocore", "boto3"]
+      "matchPackageNames": ["botocore", "boto3"],
+      "groupName": "botocore"
     }
   ]
 }


### PR DESCRIPTION
Add the missing `groupName` configuration option so that the matched packages are included into common PRs.

Link: https://docs.renovatebot.com/configuration-options/#groupname