### PR TITLE
chore: reenable cla-check at repo level

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -1,0 +1,11 @@
+name: cla-check
+
+on: [pull_request]
+
+jobs:
+    cla-check:
+        runs-on: ubuntu-latest
+        if: github.actor != 'maas-lander'
+        steps:
+            - name: Check if CLA signed
+              uses: canonical/has-signed-canonical-cla@v2


### PR DESCRIPTION
This is no longer running as part of the canonical org level actions.