### PR TITLE
docs: removed noop message for list-backups action

### DIFF
--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -108,7 +108,6 @@ actions:
   list-backups:
     description: |
       List available MAAS backups
-      NOTE - This is a noop action, and serves only as a placeholder
 
 parts:
   charm:


### PR DESCRIPTION
I believe this was left there from development.  It is not a noop.

Ideally this would make it into the backport to 3.7 https://github.com/canonical/maas-charms/pull/575