### PR TITLE
chore: fix linting

### DIFF
--- a/maas-region/pyproject.toml
+++ b/maas-region/pyproject.toml
@@ -4,7 +4,6 @@
 target-version = "py310"
 line-length = 99
 extend-exclude = [ "*.egg_info", "__pycache__" ]
-
 lint.select = [
   "C",
   "D",
@@ -38,21 +37,19 @@ lint.mccabe.max-complexity = 10
 [tool.codespell]
 skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
-[tool.pytest.ini_options]
-minversion = "6.0"
-log_cli_level = "INFO"
-filterwarnings = [
+[tool.pytest]
+ini_options.minversion = "6.0"
+ini_options.log_cli_level = "INFO"
+ini_options.filterwarnings = [
   "ignore::PendingDeprecationWarning",
   "ignore::DeprecationWarning",
 ]
 
-[tool.coverage.report]
-show_missing = true
-
+[tool.coverage]
 # Formatting tools configuration
 
-[tool.coverage.run]
-branch = true
+run.branch = true
+report.show_missing = true
 
 [tool.pyright]
 include = [ "src/**.py" ]


### PR DESCRIPTION
Format pyproject.toml to adapt to the checks of the newer version of pyproject-fmt