### PR TITLE
fix: set backend server timeout

### DIFF
--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -102,6 +102,7 @@ COMMON_DEFAULT_HAPROXY_ARGS = {
     "check_rise": 2,
     "check_fall": 3,
     "check_interval": 2,
+    "server_timeout": 900,
 }
 
 


### PR DESCRIPTION
Set the backend server timeout to 15 minutes to give MAAS enough time to finish most of the heavy API operations before HAProxy timeout is triggered

Resolves: #597