### PR TITLE
fix: properly calculate MAAS URL

### DIFF
--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -12,6 +12,7 @@ import string
 import subprocess
 from ipaddress import ip_address
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 import ops
 from charms.data_platform_libs.v0 import data_interfaces as db
@@ -305,18 +306,22 @@ class MaasRegionCharm(ops.CharmBase):
         if maas_url := self.config["maas_url"]:
             return str(maas_url)
 
-        scheme, port, proxy_port = (
-            ("https", MAAS_HTTPS_PORT, MAAS_TLS_PROXY_PORT)
+        scheme, port, relation_name = (
+            ("https", MAAS_HTTPS_PORT, HAPROXY_TLS)
             if self.is_tls_config_enabled
-            else ("http", MAAS_HTTP_PORT, MAAS_PROXY_PORT)
+            else ("http", MAAS_HTTP_PORT, HAPROXY_NON_TLS)
         )
 
         # TODO: Read the vip from HAProxy, if the relation exists, once
         # https://github.com/canonical/haproxy-operator/issues/365 or similar is implemented
-        if relation := self.model.get_relation(HAPROXY_NON_TLS):
-            unit = next(iter(relation.units), None)
-            if unit and (addr := relation.data[unit].get("public-address")):
-                return f"{scheme}://{addr}:{proxy_port}/MAAS"
+        if relation := self.model.get_relation(relation_name):
+            if endpoints := relation.data[relation.app].get("endpoints"):
+                try:
+                    endpoint_list = json.loads(endpoints)
+                    if isinstance(endpoint_list, list) and endpoint_list:
+                        return f"{scheme}://{endpoint_list[0]}/MAAS"
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning(f"Invalid endpoints format from HAProxy: {endpoints}")
         return f"{scheme}://{self.bind_address}:{port}/MAAS"
 
     @property
@@ -327,14 +332,22 @@ class MaasRegionCharm(ops.CharmBase):
             str: The API URL
         """
         if maas_url := self.config["maas_url"]:
-            return str(maas_url)
+            parsed = urlparse(str(maas_url))
+            # Force http scheme for internal API initialization
+            if parsed.scheme == "https":
+                parsed = parsed._replace(scheme="http")
+            return urlunparse(parsed)
 
         # TODO: Read the vip from HAProxy, if the relation exists, once
         # https://github.com/canonical/haproxy-operator/issues/365 or similar is implemented
         if relation := self.model.get_relation(HAPROXY_NON_TLS):
-            unit = next(iter(relation.units), None)
-            if unit and (addr := relation.data[unit].get("public-address")):
-                return f"http://{addr}:{MAAS_PROXY_PORT}/MAAS"
+            if endpoints := relation.data[relation.app].get("endpoints"):
+                try:
+                    endpoint_list = json.loads(endpoints)
+                    if isinstance(endpoint_list, list) and endpoint_list:
+                        return f"http://{endpoint_list[0]}/MAAS"
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning(f"Invalid endpoints format from HAProxy: {endpoints}")
         return f"http://{self.bind_address}:{MAAS_HTTP_PORT}/MAAS"
 
     @property
@@ -772,6 +785,14 @@ class MaasRegionCharm(ops.CharmBase):
             if not cert or not key:
                 raise ValueError(
                     "Both ssl_cert_content and ssl_key_content must be defined when using configuring TLS"
+                )
+
+        # validate maas_url if provided
+        if maas_url := self.config["maas_url"]:
+            parsed = urlparse(str(maas_url))
+            if not parsed.scheme or not parsed.netloc:
+                raise ValueError(
+                    f"Invalid maas_url: {maas_url}. Must be a valid URL with scheme and host."
                 )
         self._reconcile_ha_proxy(event)
         maas_details = MaasHelper.get_maas_details()

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -320,7 +320,7 @@ class MaasRegionCharm(ops.CharmBase):
                     endpoint_list = json.loads(endpoints)
                     if isinstance(endpoint_list, list) and endpoint_list:
                         return f"{scheme}://{endpoint_list[0]}/MAAS"
-                except (json.JSONDecodeError, TypeError):
+                except json.JSONDecodeError:
                     logger.warning(f"Invalid endpoints format from HAProxy: {endpoints}")
         return f"{scheme}://{self.bind_address}:{port}/MAAS"
 
@@ -346,7 +346,7 @@ class MaasRegionCharm(ops.CharmBase):
                     endpoint_list = json.loads(endpoints)
                     if isinstance(endpoint_list, list) and endpoint_list:
                         return f"http://{endpoint_list[0]}/MAAS"
-                except (json.JSONDecodeError, TypeError):
+                except json.JSONDecodeError:
                     logger.warning(f"Invalid endpoints format from HAProxy: {endpoints}")
         return f"http://{self.bind_address}:{MAAS_HTTP_PORT}/MAAS"
 

--- a/maas-region/tests/integration/test_charm.py
+++ b/maas-region/tests/integration/test_charm.py
@@ -68,7 +68,7 @@ async def test_database_integration(ops_test: OpsTest):
     )
 
 
-def generate_cert(ip_address: str, tmp_path: Path):
+def generate_cert(ip_addresses: list[str], tmp_path: Path):
     ca_key = tmp_path / "ca.key"
     ca_crt = tmp_path / "ca.crt"
     maas_key = tmp_path / "maas.key"
@@ -76,6 +76,7 @@ def generate_cert(ip_address: str, tmp_path: Path):
     maas_crt = tmp_path / "maas.crt"
     conf = tmp_path / "maas.conf"
 
+    alt_names = "\n".join(f"IP.{i + 1} = {ip}" for i, ip in enumerate(ip_addresses))
     conf.write_text(f"""\
 [ req ]
 default_bits       = 4096
@@ -85,13 +86,13 @@ distinguished_name = dn
 req_extensions     = req_ext
 
 [ dn ]
-CN = {ip_address}
+CN = {ip_addresses[0]}
 
 [ req_ext ]
 subjectAltName = @alt_names
 
 [ alt_names ]
-IP.1 = {ip_address}
+{alt_names}
 """)
 
     for key in [ca_key, maas_key]:
@@ -187,8 +188,9 @@ async def test_haproxy_integration(ops_test: OpsTest, tmp_path):
     )
 
     address = await ops_test.model.applications[APP_NAME].units[0].get_public_address()
+    haproxy_address = await ops_test.model.applications["haproxy"].units[0].get_public_address()
 
-    key, cacert, cert = generate_cert(ip_address=address, tmp_path=tmp_path)
+    key, cacert, cert = generate_cert(ip_addresses=[address, haproxy_address], tmp_path=tmp_path)
     await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp", "haproxy")
     await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp-temporal", "haproxy")
     await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp-internal-http-api", "haproxy")

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -214,6 +214,17 @@ class TestClusterUpdates(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.harness.update_config({"ssl_cert_content": "test_cert"})
 
+    def test_invalid_maas_url_config(self):
+        """Test that invalid maas_url raises ValueError on config change."""
+        invalid_urls = ["not-a-url", "/just/a/path", "http://"]
+        for invalid_url in invalid_urls:
+            with self.subTest(url=invalid_url):
+                harness = self._make_harness()
+                harness.begin()
+                with self.assertRaises(ValueError) as cm:
+                    harness.update_config({"maas_url": invalid_url})
+                self.assertIn("Invalid maas_url", str(cm.exception))
+
     @patch("charm.MaasHelper", autospec=True)
     def test_on_maas_cluster_changed_prometheus_enabled(self, mock_helper):
         mock_helper.get_maas_mode.return_value = "region"
@@ -710,3 +721,126 @@ class TestCharmActions(unittest.TestCase):
         self.harness.begin()
         with self.assertRaises(subprocess.CalledProcessError):
             self.harness.charm.get_region_system_ids()
+
+
+class TestMAASURLs(unittest.TestCase):
+    """Test maas_cli_url and maas_api_url properties."""
+
+    def setUp(self):
+        self.harness = ops.testing.Harness(MaasRegionCharm)
+        self.harness.add_network("10.0.0.10")
+        self.addCleanup(self.harness.cleanup)
+
+    def test_maas_cli_url_with_config(self):
+        """Test maas_cli_url returns configured URL when maas_url is set."""
+        self.harness.update_config({"maas_url": "https://custom.maas.example.com/MAAS"})
+        self.harness.begin()
+        self.assertEqual(self.harness.charm.maas_cli_url, "https://custom.maas.example.com/MAAS")
+
+    def test_maas_cli_url_with_haproxy_non_tls(self):
+        """Test maas_cli_url uses HAProxy non-TLS endpoint when TLS is disabled."""
+        self.harness.begin()
+        rel_id = self.harness.add_relation(HAPROXY_NON_TLS, "haproxy")
+        self.harness.update_relation_data(rel_id, "haproxy", {"endpoints": '["10.226.71.86:80"]'})
+        self.assertEqual(self.harness.charm.maas_cli_url, "http://10.226.71.86:80/MAAS")
+
+    def test_maas_cli_url_with_haproxy_tls(self):
+        """Test maas_cli_url uses HAProxy TLS endpoint when TLS is enabled."""
+        self.harness.update_config(
+            {
+                "ssl_cert_content": "cert-content",
+                "ssl_key_content": "key-content",
+            }
+        )
+        self.harness.begin()
+        rel_id = self.harness.add_relation(HAPROXY_TLS, "haproxy")
+        self.harness.update_relation_data(rel_id, "haproxy", {"endpoints": '["10.226.71.86:443"]'})
+        self.assertEqual(self.harness.charm.maas_cli_url, "https://10.226.71.86:443/MAAS")
+
+    def test_maas_cli_url_fallback_to_bind_address_non_tls(self):
+        """Test maas_cli_url falls back to bind address when no HAProxy (non-TLS)."""
+        self.harness.begin()
+        self.assertEqual(
+            self.harness.charm.maas_cli_url, f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS"
+        )
+
+    def test_maas_cli_url_fallback_to_bind_address_tls(self):
+        """Test maas_cli_url falls back to bind address when no HAProxy (TLS)."""
+        self.harness.update_config(
+            {
+                "ssl_cert_content": "cert-content",
+                "ssl_key_content": "key-content",
+            }
+        )
+        self.harness.begin()
+        self.assertEqual(
+            self.harness.charm.maas_cli_url, f"https://10.0.0.10:{MAAS_HTTPS_PORT}/MAAS"
+        )
+
+    def test_maas_cli_url_handles_malformed_endpoints(self):
+        """Test maas_cli_url handles malformed HAProxy endpoints and falls back to bind address."""
+        cases = [
+            ("invalid_json", "invalid-json"),
+            ("empty_list", "[]"),
+            ("non_list_json", '{"key": "value"}'),
+        ]
+        for name, endpoints_value in cases:
+            with self.subTest(case=name):
+                self.harness.begin()
+                rel_id = self.harness.add_relation(HAPROXY_NON_TLS, "haproxy")
+                self.harness.update_relation_data(
+                    rel_id, "haproxy", {"endpoints": endpoints_value}
+                )
+                self.assertEqual(
+                    self.harness.charm.maas_cli_url, f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS"
+                )
+                self.harness.cleanup()
+                self.harness = ops.testing.Harness(MaasRegionCharm)
+                self.harness.add_network("10.0.0.10")
+
+    def test_maas_api_url_with_config(self):
+        """Test maas_api_url converts https to http from configured URL."""
+        self.harness.update_config({"maas_url": "https://custom.maas.example.com/MAAS"})
+        self.harness.begin()
+        self.assertEqual(self.harness.charm.maas_api_url, "http://custom.maas.example.com/MAAS")
+
+    def test_maas_api_url_with_http_config(self):
+        """Test maas_api_url keeps http scheme from configured URL."""
+        self.harness.update_config({"maas_url": "http://custom.maas.example.com/MAAS"})
+        self.harness.begin()
+        self.assertEqual(self.harness.charm.maas_api_url, "http://custom.maas.example.com/MAAS")
+
+    def test_maas_api_url_with_haproxy(self):
+        """Test maas_api_url uses HAProxy non-TLS endpoint."""
+        self.harness.begin()
+        rel_id = self.harness.add_relation(HAPROXY_NON_TLS, "haproxy")
+        self.harness.update_relation_data(rel_id, "haproxy", {"endpoints": '["10.226.71.86:80"]'})
+        self.assertEqual(self.harness.charm.maas_api_url, "http://10.226.71.86:80/MAAS")
+
+    def test_maas_api_url_fallback_to_bind_address(self):
+        """Test maas_api_url falls back to bind address when no HAProxy."""
+        self.harness.begin()
+        self.assertEqual(
+            self.harness.charm.maas_api_url, f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS"
+        )
+
+    def test_maas_api_url_handles_malformed_endpoints(self):
+        """Test maas_api_url handles malformed HAProxy endpoints and falls back to bind address."""
+        cases = [
+            ("invalid_json", "invalid-json"),
+            ("empty_list", "[]"),
+            ("non_list_json", '{"key": "value"}'),
+        ]
+        for name, endpoints_value in cases:
+            with self.subTest(case=name):
+                self.harness.begin()
+                rel_id = self.harness.add_relation(HAPROXY_NON_TLS, "haproxy")
+                self.harness.update_relation_data(
+                    rel_id, "haproxy", {"endpoints": endpoints_value}
+                )
+                self.assertEqual(
+                    self.harness.charm.maas_api_url, f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS"
+                )
+                self.harness.cleanup()
+                self.harness = ops.testing.Harness(MaasRegionCharm)
+                self.harness.add_network("10.0.0.10")


### PR DESCRIPTION
- Add validation to `maas-url` configuration option to allow only valid URLs
- Apply `http` scheme to `maas_url` used in region/rack configuration files if it is calculated by the `maas-url` config option and the option points to a URL with `https` scheme
- Properly calculate the URL if related with HAProxy and the endpoints information is provided in the relation data bag

Resolves: #600