### PR TITLE
ci: explicitly set the permissions needed for observability reusable workflows

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@v0
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
     with:
       charm-path: ${{ github.event.inputs.charm }}
       promotion: ${{ github.event.inputs.promotion }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,7 +9,11 @@ on:
 jobs:
   pull-request-region:
     name: PR Region
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v0
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
     secrets: inherit
     with:
       charm-path: maas-region

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,11 @@ jobs:
     name: Release MAAS Region charm to edge
     needs: detect-region-changes
     if: needs.detect-region-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@v0
+    uses: canonical/observability/.github/workflows/charm-release.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
     secrets: inherit
     with:
       charm-path: maas-region

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: "0 0,4,8,12,16,20 * * *"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-lib-region:
     name: Check libraries

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-lib-region:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v0
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -6,36 +6,15 @@ on:
   schedule:
     - cron: "0 0,4,8,12,16,20 * * *"
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   update-lib-region:
     name: Check libraries
     uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v0
+    permissions:
+      contents: write
+      pull-requests: write
     secrets: inherit
     with:
       charm-path: maas-region
       commit-username: maas-lander
       commit-email: 115650013+maas-lander@users.noreply.github.com
-
-  detect-open-prs:
-    name: Check open library updates PRs
-    needs: update-lib-region
-    runs-on: ubuntu-24.04
-    outputs:
-      open_prs: ${{ steps.open-prs.outputs.open_prs }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Check for any pre-existing PR and save it in the output
-        id: open-prs
-        run: |
-          OPEN_PRS="$(gh pr list --head chore/auto-libs --state open --json id --jq 'length')"
-          echo "open_prs=$OPEN_PRS" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}


### PR DESCRIPTION
Also delete the unnecessary job to check for open PRs, as it is a leftover from the era of maas-agent charm, not properly removed.