### PR TITLE
backport to 3.7 track

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@v0
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
     with:
       charm-path: ${{ github.event.inputs.charm }}
       promotion: ${{ github.event.inputs.promotion }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,7 +9,11 @@ on:
 jobs:
   pull-request-region:
     name: PR Region
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v0
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
     secrets: inherit
     with:
       charm-path: maas-region

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,11 @@ jobs:
     name: Release MAAS Region charm to edge
     needs: detect-region-changes
     if: needs.detect-region-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@v0
+    uses: canonical/observability/.github/workflows/charm-release.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
     secrets: inherit
     with:
       charm-path: maas-region

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,29 +9,12 @@ on:
 jobs:
   update-lib-region:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v0
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
+    permissions:
+      contents: write
+      pull-requests: write
     secrets: inherit
     with:
       charm-path: maas-region
       commit-username: maas-lander
       commit-email: 115650013+maas-lander@users.noreply.github.com
-
-  detect-open-prs:
-    name: Check open library updates PRs
-    needs: update-lib-region
-    runs-on: ubuntu-24.04
-    outputs:
-      open_prs: ${{ steps.open-prs.outputs.open_prs }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Check for any pre-existing PR and save it in the output
-        id: open-prs
-        run: |
-          OPEN_PRS="$(gh pr list --head chore/auto-libs --state open --json id --jq 'length')"
-          echo "open_prs=$OPEN_PRS" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}

--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -44,6 +44,14 @@ requires:
     interface: s3
     limit: 1
     optional: true
+  ingress-tcp:
+    interface: haproxy-route-tcp
+    limit: 1
+    optional: true
+  ingress-tcp-tls:
+    interface: haproxy-route-tcp
+    limit: 1
+    optional: true
 
 peers:
   initialize:
@@ -54,9 +62,6 @@ peers:
     optional: false
 
 provides:
-  api:
-    interface: http
-    optional: true
   cos-agent:
     interface: cos_agent
     optional: true
@@ -161,25 +166,20 @@ config:
     maas_url:
       default: ""
       description: |
-        The maas_url to set. If not provided, the maas_url is formulated by the IP of maas-region
-        leader and MAAS API port. If application is related to HAProxy, the proxy port is used
-        instead.
-      type: string
-    tls_mode:
-      default: "disabled"
-      description: Whether to enable TLS termination at HA Proxy ('termination'), at MAAS ('passthrough'), or no TLS ('disabled')
+        The `maas_url` to set. If not provided, and related to HAProxy, the `maas_url` is formed of any HAProxy unit IP address and the proxy port,
+        otherwise, the `maas_url` is formulated by the IP of any maas-region unit and MAAS API port.
       type: string
     ssl_cert_content:
       default: ""
-      description: SSL certificate for tls_mode='passthrough'
+      description: SSL certificate. If provided, MAAS will run in TLS mode, and will require `ssl_key_content` to be provided.
       type: string
     ssl_key_content:
       default: ""
-      description: SSL private key for tls_mode='passthrough'
+      description: SSL private key. If provided, MAAS will run in TLS mode, and will require `ssl_cert_content` to be provided.
       type: string
     ssl_cacert_content:
       default: ""
-      description: CA Certificates chain in PEM format
+      description: CA Certificates chain in PEM format. If MAAS is running in TLS mode, and the `ssl_key_content` and `ssl_cert_content` are provided, the `ssl_cacert_content` can be provided for self signed certificate.
       type: string
     enable_prometheus_metrics:
       default: true

--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -96,6 +96,8 @@ actions:
     description: Get MAAS API URL
   get-maas-secret:
     description: Get MAAS secret
+  get-maas-status:
+    description: Get MAAS status. Run on each unit to get its individual status.
   create-backup:
     description: Create a backup of MAAS data not stored in the database.
   restore-backup:

--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -52,6 +52,14 @@ requires:
     interface: haproxy-route-tcp
     limit: 1
     optional: true
+  ingress-tcp-temporal:
+    interface: haproxy-route-tcp
+    limit: 1
+    optional: true
+  ingress-tcp-internal-http-api:
+    interface: haproxy-route-tcp
+    limit: 1
+    optional: true
 
 peers:
   initialize:

--- a/maas-region/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/maas-region/lib/charms/grafana_agent/v0/cos_agent.py
@@ -211,7 +211,9 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm)
 ```
 """
 
+import copy
 import enum
+import hashlib
 import json
 import logging
 import socket
@@ -254,7 +256,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 24
+LIBPATCH = 25
 
 PYDEPS = ["cosl >= 0.0.50", "pydantic"]
 
@@ -306,6 +308,13 @@ def _dedupe_list(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         if item not in unique_items:
             unique_items.append(item)
     return unique_items
+
+
+def _dict_hash_except_key(scrape_config: Dict[str, Any], key: Optional[str]):
+    """Get a hash of the scrape_config dict, except for the specified key."""
+    cfg_for_hash = {k: v for k, v in scrape_config.items() if k != key}
+    serialized = json.dumps(cfg_for_hash, sort_keys=True)
+    return hashlib.blake2b(serialized.encode(), digest_size=4).hexdigest()
 
 
 class TracingError(Exception):
@@ -697,6 +706,27 @@ class COSAgentProvider(Object):
                 ) as e:
                     logger.error("Invalid relation data provided: %s", e)
 
+    def _deterministic_scrape_configs(
+        self, scrape_configs: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Get deterministic scrape_configs with stable job names.
+
+        For stability across serializations, compute a short per-config hash
+        and append it to the existing job name (or 'default'). Keep the app
+        name as a prefix: <app>_<job_or_default>_<8hex-hash>.
+
+        Hash the whole scrape_config (except any existing job_name) so the
+        suffix is sensitive to all stable fields. Use deterministic JSON
+        serialization.
+        """
+        local_scrape_configs = copy.deepcopy(scrape_configs)
+        for scrape_config in local_scrape_configs:
+            name = scrape_config.get("job_name", "default")
+            short_id = _dict_hash_except_key(scrape_config, "job_name")
+            scrape_config["job_name"] = f"{self._charm.app.name}_{name}_{short_id}"
+
+        return sorted(local_scrape_configs, key=lambda c: c.get("job_name", ""))
+
     @property
     def _scrape_jobs(self) -> List[Dict]:
         """Return a list of scrape_configs.
@@ -711,22 +741,17 @@ class COSAgentProvider(Object):
             scrape_configs = self._scrape_configs.copy()
 
         # Convert "metrics_endpoints" to standard scrape_configs, and add them in
-        unit_name = self._charm.unit.name.replace("/", "_")
         for endpoint in self._metrics_endpoints:
-            port = endpoint["port"]
-            path = endpoint["path"]
-            sanitized_path = path.strip("/").replace("/", "_")
             scrape_configs.append(
                 {
-                    "job_name": f"{unit_name}_localhost_{port}_{sanitized_path}",
-                    "metrics_path": path,
-                    "static_configs": [{"targets": [f"localhost:{port}"]}],
+                    "metrics_path": endpoint["path"],
+                    "static_configs": [{"targets": [f"localhost:{endpoint['port']}"]}],
                 }
             )
 
         scrape_configs = scrape_configs or []
 
-        return scrape_configs
+        return self._deterministic_scrape_configs(scrape_configs)
 
     @property
     def _metrics_alert_rules(self) -> Dict:
@@ -742,7 +767,7 @@ class COSAgentProvider(Object):
         )
         alert_rules.add_path(self._metrics_rules, recursive=self._recursive)
         alert_rules.add(
-            generic_alert_groups.application_rules,
+            copy.deepcopy(generic_alert_groups.application_rules),
             group_name_prefix=JujuTopology.from_charm(self._charm).identifier,
         )
 

--- a/maas-region/lib/charms/haproxy/v0/haproxy_route_tcp.py
+++ b/maas-region/lib/charms/haproxy/v0/haproxy_route_tcp.py
@@ -1,0 +1,1729 @@
+# pylint: disable=too-many-lines,duplicate-code
+"""Haproxy-route interface library.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.haproxy.v1.haproxy_route_tcp
+```
+
+In the `metadata.yaml` of the charm, add the following:
+
+```yaml
+requires:
+    backend-tcp:
+        interface: haproxy-route-tcp
+        limit: 1
+```
+
+Then, to initialise the library:
+
+```python
+from charms.haproxy.v0.haproxy_route_tcp import HaproxyRouteTcpRequirer
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+
+    # There are 2 ways you can use the requirer implementation:
+    # 1. To initialize the requirer with parameters:
+    self.haproxy_route_tcp_requirer = HaproxyRouteTcpRequirer(
+        self,
+        relation_name="haproxy-route-tcp"
+        port=<optional>  # The port exposed on the provider.
+        backend_port=<optional>  # The port where the backend service is listening.
+        hosts=<optional>  # List of backend server addresses. Currently only support IP addresses.
+        sni=<optional>  # Server name identification. Used to route traffic to the service.
+        check_interval=<optional>  # Interval between health checks in seconds.
+        check_rise=<optional>  # Number of successful health checks
+            before server is considered up.
+        check_fall=<optional>  # Number of failed health checks before server is considered down.
+        check_type=<optional>  # Can be 'generic', 'mysql', 'postgres', 'redis' or 'smtp'ßß.
+        check_send=<optional>  # Only used in generic health checks,
+            specify a string to send in the health check request.
+        check_expect=<optional>  # Only used in generic health checks,
+            specify the expected response from a health check request.
+        check_db_user=<optional>  # Only used if type is postgres or mysql,
+            specify the user name to enable HAproxy to send a Client Authentication packet.
+        load_balancing_algorithm=<optional>  # Algorithm to use for load balancing.
+        load_balancing_consistent_hashing=<optional>  # Whether to use consistent hashing.
+        rate_limit_connections_per_minute=<optional>  # Maximum connections allowed per minute.
+        rate_limit_policy=<optional>  # Policy to apply when rate limit is reached.
+        upload_limit=<optional>  # Maximum upload bandwidth in bytes per second.
+        download_limit=<optional>  # Maximum download bandwidth in bytes per second.
+        retry_count=<optional>  # Number of times to retry failed requests.
+        retry_redispatch=<optional>  # Whether to redispatch failed requests to another server.
+        server_timeout=<optional>  # Timeout for requests from haproxy
+            to backend servers in seconds.
+        connect_timeout=<optional>  # Timeout for client requests to haproxy in seconds.
+        queue_timeout=<optional>  # Timeout for requests waiting in queue in seconds.
+        server_maxconn=<optional>  # Maximum connections per server.
+        ip_deny_list=<optional>  # List of source IP addresses to block.
+        enforce_tls=<optional>  # Whether to enforce TLS for all traffic coming to the backend.
+        tls_terminate=<optional>  # Whether to enable tls termination on the dedicated frontend.
+        unit_address=<optional>  # IP address of the unit
+            (if not provided, will use binding address).
+    )
+
+    # 2.To initialize the requirer with no parameters, i.e
+    # self.haproxy_route_tcp_requirer = HaproxyRouteTcpRequirer(self)
+    # This will simply initialize the requirer class and it won't perfom any action.
+
+    # Afterwards regardless of how you initialized the requirer you can call the
+    # provide_haproxy_route_requirements method anywhere in your charm to update the requirer data.
+    # The method takes the same number of parameters as the requirer class.
+    # provide_haproxy_route_tcp_requirements(port=, ...)
+
+    self.framework.observe(
+        self.framework.on.config_changed, self._on_config_changed
+    )
+    self.framework.observe(
+        self.haproxy_route_tcp_requirer.on.ready, self._on_endpoints_ready
+    )
+    self.framework.observe(
+        self.haproxy_route_tcp_requirer.on.removed, self._on_endpoints_removed
+    )
+
+    def _on_config_changed(self, event: ConfigChangedEvent) -> None:
+        self.haproxy_route_tcp_requirer.provide_haproxy_route_tcp_requirements(...)
+
+    def _on_endpoints_ready(self, _: EventBase) -> None:
+        # Handle endpoints ready event
+        if endpoints := self.haproxy_route_tcp_requirer.get_proxied_endpoints():
+            # Do something with the endpoints information
+        ...
+
+    def _on_endpoints_removed(self, _: EventBase) -> None:
+        # Handle endpoints removed event
+        ...
+
+    # 3.To initialize the requirer together with helper methods.
+    # This will use chaining of the helper methods to populate the requirer
+    # data attributes.
+    self.haproxy_tcp_route_requirer = HaproxyRouteTcpRequirer(self, relation_name="") \
+        .configure_port(4000) \
+        .configure_backend_port(5000) \
+        .configure_health_check(60, 5, 5) \
+        .configure_rate_limit(10, TCPRateLimitPolicy.SILENT) \
+        .update_relation_data()
+
+
+## Using the library as the provider
+The provider charm should expose the interface as shown below:
+```yaml
+provides:
+    haproxy-route-tcp:
+        interface: haproxy-route-tcp
+```
+Note that this interface supports relating to multiple endpoints.
+
+Then, to initialise the library:
+```python
+from charms.haproxy.v0.haproxy_route import HaproxyRouteTcpProvider
+
+class SomeCharm(CharmBase):
+    self.haproxy_route_tcp_provider = HaproxyRouteTcpProvider(self)
+    self.framework.observe(
+        self.haproxy_route_tcp_provider.on.data_available, self._on_haproxy_route_data_available
+    )
+
+    def _on_haproxy_route_data_available(self, event: EventBase) -> None:
+        data = self.haproxy_route_tcp_provider.get_data(self.haproxy_route_tcp_provider.relations)
+        # data is an object of the `HaproxyRouteTcpRequirersData` class, see below for the
+        # available attributes
+        ...
+
+        # Publish the endpoints to the requirers
+        for requirer_data in data.requirers_data:
+            self.haproxy_route_tcp.publish_proxied_endpoints(
+                ["..."], requirer_data.relation_id
+            )
+"""
+
+import json
+import logging
+from collections import defaultdict
+from enum import Enum
+from typing import Annotated, Any, MutableMapping, Optional, cast
+
+from ops import CharmBase, ModelError, RelationBrokenEvent
+from ops.charm import CharmEvents
+from ops.framework import EventBase, EventSource, Object
+from ops.model import Relation
+from pydantic import (
+    AnyUrl,
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    IPvAnyAddress,
+    ValidationError,
+    model_validator,
+)
+from pydantic.dataclasses import dataclass
+from typing_extensions import Self
+
+# The unique Charmhub library identifier, never change it
+LIBID = "b1b5c0a6f1b5481c9923efa042846681"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+logger = logging.getLogger(__name__)
+HAPROXY_ROUTE_TCP_RELATION_NAME = "haproxy-route-tcp"
+HAPROXY_CONFIG_INVALID_CHARACTERS = "\n\t#\\'\"\r$ "
+
+
+def value_contains_invalid_characters(value: Optional[str]) -> Optional[str]:
+    """Validate if value contains invalid haproxy config characters.
+
+    Args:
+        value: The value to validate.
+
+    Raises:
+        ValueError: When value contains invalid characters.
+
+    Returns:
+        The validated value.
+    """
+    if value is None:
+        return value
+
+    if [char for char in value if char in HAPROXY_CONFIG_INVALID_CHARACTERS]:
+        raise ValueError(f"Relation data contains invalid character(s) {value}")
+    return value
+
+
+VALIDSTR = Annotated[str, BeforeValidator(value_contains_invalid_characters)]
+
+
+class DataValidationError(Exception):
+    """Raised when data validation fails."""
+
+
+class HaproxyRouteTcpInvalidRelationDataError(Exception):
+    """Raised when data validation of the haproxy-route relation fails."""
+
+
+class _DatabagModel(BaseModel):
+    """Base databag model.
+
+    Attrs:
+        model_config: pydantic model configuration.
+    """
+
+    model_config = ConfigDict(
+        # tolerate additional keys in databag
+        extra="ignore",
+        # Allow instantiating this class by field name (instead of forcing alias).
+        populate_by_name=True,
+        # Custom config key: whether to nest the whole datastructure (as json)
+        # under a field or spread it out at the toplevel.
+        _NEST_UNDER=None,
+    )  # type: ignore
+    """Pydantic config."""
+
+    @classmethod
+    def load(cls, databag: MutableMapping) -> "_DatabagModel":
+        """Load this model from a Juju json databag.
+
+        Args:
+            databag: Databag content.
+
+        Raises:
+            DataValidationError: When model validation failed.
+
+        Returns:
+            _DatabagModel: The validated model.
+        """
+        nest_under = cls.model_config.get("_NEST_UNDER")
+        if nest_under:
+            return cls.model_validate(json.loads(databag[nest_under]))
+
+        try:
+            data = {
+                k: json.loads(v)
+                for k, v in databag.items()
+                # Don't attempt to parse model-external values
+                if k in {(f.alias or n) for n, f in cls.model_fields.items()}
+            }
+        except json.JSONDecodeError as e:
+            msg = f"invalid databag contents: expecting json. {databag}"
+            logger.error(msg)
+            raise DataValidationError(msg) from e
+
+        try:
+            return cls.model_validate_json(json.dumps(data))
+        except ValidationError as e:
+            msg = f"failed to validate databag: {databag}"
+            logger.error(str(e), exc_info=True)
+            raise DataValidationError(msg) from e
+
+    @classmethod
+    def from_dict(cls, values: dict) -> "_DatabagModel":
+        """Load this model from a dict.
+
+        Args:
+            values: Dict values.
+
+        Raises:
+            DataValidationError: When model validation failed.
+
+        Returns:
+            _DatabagModel: The validated model.
+        """
+        try:
+            logger.info("Loading values from dictionary: %s", values)
+            return cls.model_validate(values)
+        except ValidationError as e:
+            msg = f"failed to validate: {values}"
+            logger.debug(msg, exc_info=True)
+            raise DataValidationError(msg) from e
+
+    def dump(
+        self, databag: Optional[MutableMapping] = None, clear: bool = True
+    ) -> Optional[MutableMapping]:
+        """Write the contents of this model to Juju databag.
+
+        Args:
+            databag: The databag to write to.
+            clear: Whether to clear the databag before writing.
+
+        Returns:
+            MutableMapping: The databag.
+        """
+        if clear and databag:
+            databag.clear()
+
+        if databag is None:
+            databag = {}
+        nest_under = self.model_config.get("_NEST_UNDER")
+        if nest_under:
+            databag[nest_under] = self.model_dump_json(
+                by_alias=True,
+                # skip keys whose values are default
+                exclude_defaults=True,
+            )
+            return databag
+
+        dct = self.model_dump(mode="json", by_alias=True, exclude_defaults=True)
+        databag.update({k: json.dumps(v) for k, v in dct.items()})
+        return databag
+
+
+class TCPHealthCheckType(Enum):
+    """Enum of possible rate limiting policies.
+
+    Attrs:
+        GENERIC: deny a client's HTTP request to return a 403 Forbidden error.
+        MYSQL: closes the connection immediately without sending a response.
+        POSTGRES: disconnects immediately without notifying the client
+            that the connection has been closed.
+        REDIS: closes the connection immediately without sending a response.
+        SMTP: closes the connection immediately without sending a response.
+    """
+
+    GENERIC = "generic"
+    MYSQL = "mysql"
+    POSTGRES = "postgres"
+    REDIS = "redis"
+    SMTP = "smtp"
+
+
+class TCPServerHealthCheck(BaseModel):
+    """Configuration model for backend server health checks.
+
+    Attributes:
+        interval: Number of seconds between consecutive health check attempts.
+        rise: Number of consecutive successful health checks required for up.
+        fall: Number of consecutive failed health checks required for DOWN.
+        check_type: Health check type, Can be “generic”, “mysql”, “postgres”, “redis” or “smtp”.
+        send: Only used in generic health checks,
+            specify a string to send in the health check request.
+        expect: Only used in generic health checks,
+            specify the expected response from a health check request.
+        db_user: Only used if type is postgres or mysql,
+            specify the user name to enable HAproxy to send a Client Authentication packet.
+    """
+
+    # interval, rise and fall don't have a default value since the class itself is optional
+    # in the requirer databag model, so once the class is instantiated we need all of the
+    # required attributes to be present as we can assume that health-check is being configured.
+    interval: int = Field(
+        description="The interval (in seconds) between health checks.",
+        gt=0,
+    )
+    rise: int = Field(
+        description="How many successful health checks before server is considered up.",
+        gt=0,
+    )
+    fall: int = Field(
+        description="How many failed health checks before server is considered down.", gt=0
+    )
+    check_type: Optional[TCPHealthCheckType] = Field(
+        description=(
+            "The health check type, can be 'generic', 'mysql', 'postgres', 'redis' or 'smtp'"
+        ),
+        default=None,
+    )
+    # send and expect does not have VALIDSTR validation because we need the flexibilty to
+    # specify anything in the health-check TCP requests. They will need to be properly
+    # sanitized / validated in the provider charm.
+    send: Optional[str] = Field(
+        description=(
+            "Only used in generic health checks, "
+            "specify a string to send in the health check request."
+        ),
+        default=None,
+    )
+    expect: Optional[str] = Field(
+        description=(
+            "Only used in generic health checks, "
+            "specify the expected response from a health check request."
+        ),
+        default=None,
+    )
+    db_user: Optional[VALIDSTR] = Field(
+        description=(
+            "Only used if type is postgres or mysql, "
+            "specify the user name to enable HAproxy to send a Client Authentication packet."
+        ),
+        default=None,
+    )
+
+    @model_validator(mode="after")
+    def check_all_required_fields_set(self) -> Self:
+        """Check that all required fields for health check are set.
+
+        Raises:
+            ValueError: When validation fails.
+
+        Returns:
+            The validated model.
+        """
+        if (
+            self.send is not None or self.expect is not None
+        ) and self.check_type != TCPHealthCheckType.GENERIC:
+            raise ValueError("send and expect can only be set if type is 'generic'")
+        if self.db_user is not None and self.check_type not in [
+            TCPHealthCheckType.MYSQL,
+            TCPHealthCheckType.POSTGRES,
+        ]:
+            raise ValueError("db_user can only be set if type is postgres or mysql")
+        return self
+
+
+# tarpit is not yet implemented
+class TCPRateLimitPolicy(Enum):
+    """Enum of possible rate limiting policies.
+
+    Attrs:
+        REJECT: Send a TCP reset packet to close the connection.
+        SILENT: disconnects immediately without notifying the client
+            that the connection has been closed (no packet sent).
+    """
+
+    REJECT = "reject"
+    SILENT = "silent-drop"
+
+
+class RateLimit(BaseModel):
+    """Configuration model for connection rate limiting.
+
+    Attributes:
+        connections_per_minute: Number of connections allowed per minute for a client.
+        policy: Action to take when the rate limit is exceeded.
+    """
+
+    connections_per_minute: int = Field(description="How many connections are allowed per minute.")
+    policy: TCPRateLimitPolicy = Field(
+        description="Configure the rate limit policy.", default=TCPRateLimitPolicy.REJECT
+    )
+
+
+class LoadBalancingAlgorithm(Enum):
+    """Enum of possible http_route types.
+
+    Attrs:
+        LEASTCONN: The server with the lowest number of connections receives the connection.
+        SRCIP: Load balance using the hash of The source IP address.
+        ROUNDROBIN: Each server is used in turns, according to their weights.
+    """
+
+    LEASTCONN = "leastconn"
+    SRCIP = "source"
+    ROUNDROBIN = "roundrobin"
+
+
+class TCPLoadBalancingConfiguration(BaseModel):
+    """Configuration model for load balancing.
+
+    Attributes:
+        algorithm: Algorithm to use for load balancing.
+        consistent_hashing: Use consistent hashing to avoid redirection
+            when servers are added/removed.
+    """
+
+    algorithm: LoadBalancingAlgorithm = Field(
+        description="Configure the load balancing algorithm for the service.",
+    )
+    # Note: Later when the generic LoadBalancingAlgorithm.HASH is implemented this attribute
+    # will also apply under that mode.
+    consistent_hashing: bool = Field(
+        description=(
+            "Only used when the `algorithm` is SRCIP. "
+            "Use consistent hashing to avoid redirection when servers are added/removed. "
+            "Default is False as it usually does not give a balanced distribution."
+        ),
+        default=False,
+    )
+
+    @model_validator(mode="after")
+    def validate_attributes(self) -> Self:
+        """Check that algorithm-specific configs are only set with their respective algorithm.
+
+        Raises:
+            ValueError: When validation fails in one of these cases:
+                1. self.cookie is not None when self.algorithm != COOKIE
+                2. self.consistent_hashing is True when algorithm is neither COOKIE nor SRCIP
+
+        Returns:
+            The validated model.
+        """
+        if self.consistent_hashing and self.algorithm != LoadBalancingAlgorithm.SRCIP:
+            raise ValueError("Consistent hashing only applies when algorithm is COOKIE or SRCIP.")
+        return self
+
+
+class BandwidthLimit(BaseModel):
+    """Configuration model for bandwidth rate limiting.
+
+    Attributes:
+        upload: Limit upload speed (bytes per second).
+        download: Limit download speed (bytes per second).
+    """
+
+    upload: Optional[int] = Field(description="Upload limit (bytes per seconds).", default=None)
+    download: Optional[int] = Field(
+        description="Download limit (bytes per seconds).", default=None
+    )
+
+
+# retry-on is not yet implemented
+class Retry(BaseModel):
+    """Configuration model for retry.
+
+    Attributes:
+        count: How many times should a request retry.
+        redispatch: Whether to redispatch failed requests to another server.
+    """
+
+    count: int = Field(description="How many times should a request retry.")
+    redispatch: bool = Field(
+        description="Whether to redispatch failed requests to another server.", default=False
+    )
+
+
+class TimeoutConfiguration(BaseModel):
+    """Configuration model for timeout.
+
+    Attributes:
+        server: Timeout for requests from haproxy to backend servers.
+        connect: Timeout for client requests to haproxy.
+        queue: Timeout for requests waiting in the queue after server-maxconn is reached.
+    """
+
+    server: Optional[int] = Field(
+        description="Timeout (in seconds) for requests from haproxy to backend servers.",
+    )
+    connect: Optional[int] = Field(
+        description="Timeout (in seconds) for client requests to haproxy.",
+    )
+    queue: Optional[int] = Field(
+        description="Timeout (in seconds) for requests in the queue.",
+    )
+
+
+class TcpRequirerApplicationData(_DatabagModel):
+    """Configuration model for HAProxy route requirer application data.
+
+    Attributes:
+        port: The port exposed on the provider.
+        backend_port: The port where the backend service is listening. Defaults to the
+            provider port.
+        hosts: List of backend server addresses. Currently only support IP addresses.
+        sni: Server name identification. Used to route traffic to the service.
+        check: TCP health check configuration
+        load_balancing: Load balancing configuration.
+        rate_limit: Rate limit configuration.
+        bandwidth_limit: Bandwith limit configuration.
+        retry: Retry configuration.
+        timeout: Timeout configuration.
+        server_maxconn: Maximum connections per server.
+        ip_deny_list: List of source IP addresses to block.
+        enforce_tls: Whether to enforce TLS for all traffic coming to the backend.
+        tls_terminate: Whether to enable tls termination on the dedicated frontend.
+    """
+
+    port: int = Field(description="The port exposed on the provider.", gt=0, le=65535)
+    backend_port: Optional[int] = Field(
+        description=(
+            "The port where the backend service is listening. Defaults to the provider port."
+        ),
+        default=None,
+        gt=0,
+        le=65525,
+    )
+    sni: Optional[VALIDSTR] = Field(
+        description=(
+            "Server name identification. Used to route traffic to the service. "
+            "Only available if TLS is enabled."
+        ),
+        default=None,
+    )
+    hosts: list[IPvAnyAddress] = Field(
+        description="The list of backend server addresses. Currently only support IP addresses.",
+        default=[],
+    )
+    check: Optional[TCPServerHealthCheck] = Field(
+        description="Configure health check for the service.",
+        default=None,
+    )
+    load_balancing: Optional[TCPLoadBalancingConfiguration] = Field(
+        description="Configure loadbalancing.", default=None
+    )
+    rate_limit: Optional[RateLimit] = Field(
+        description="Configure rate limit for the service.", default=None
+    )
+    bandwidth_limit: Optional[BandwidthLimit] = Field(
+        description="Configure bandwidth limit for the service.", default=None
+    )
+    retry: Optional[Retry] = Field(
+        description="Configure retry for incoming requests.", default=None
+    )
+    timeout: Optional[TimeoutConfiguration] = Field(
+        description="Configure timeout",
+        default=None,
+    )
+    server_maxconn: Optional[int] = Field(
+        description="Configure maximum connection per server", default=None
+    )
+    ip_deny_list: list[IPvAnyAddress] = Field(
+        description="List of IP addresses to block.", default=[]
+    )
+    enforce_tls: bool = Field(description="Whether to enforce TLS for all traffic.", default=True)
+    tls_terminate: bool = Field(description="Whether to enable tls termination.", default=True)
+
+    @model_validator(mode="after")
+    def assign_default_backend_port(self) -> "Self":
+        """Assign a default value to backend_port if not set.
+
+        The value is equal to the provider port.
+
+        Returns:
+            The model with backend_port default value applied.
+        """
+        if self.backend_port is None:
+            self.backend_port = self.port
+        return self
+
+    @model_validator(mode="after")
+    def sni_set_when_not_enforcing_tls(self) -> "Self":
+        """Check if sni is configured but TLS is disabled.
+
+        Raises:
+            ValueError: If sni is configured and TLS is disabled.
+
+        Returns:
+            The validated model.
+        """
+        if not self.enforce_tls and self.sni is not None:
+            raise ValueError("You can't set SNI and disable TLS at the same time.")
+        return self
+
+
+class HaproxyRouteTcpProviderAppData(_DatabagModel):
+    """haproxy-route provider databag schema.
+
+    Attributes:
+        endpoints: The list of proxied endpoints that maps to the backend.
+    """
+
+    endpoints: list[AnyUrl]
+
+
+class TcpRequirerUnitData(_DatabagModel):
+    """haproxy-route requirer unit data.
+
+    Attributes:
+        address: IP address of the unit.
+    """
+
+    address: IPvAnyAddress = Field(description="IP address of the unit.")
+
+
+@dataclass
+class HaproxyRouteTcpRequirerData:
+    """haproxy-route requirer data.
+
+    Attributes:
+        relation_id: Id of the relation.
+        application: Name of the requirer application.
+        application_data: Application data.
+        units_data: Units data
+    """
+
+    relation_id: int
+    application: str
+    application_data: TcpRequirerApplicationData
+    units_data: list[TcpRequirerUnitData]
+
+
+@dataclass
+class HaproxyRouteTcpRequirersData:
+    """haproxy-route requirers data.
+
+    Attributes:
+        requirers_data: List of requirer data.
+        relation_ids_with_invalid_data: Set of relation ids that contains invalid data.
+    """
+
+    requirers_data: list[HaproxyRouteTcpRequirerData]
+    relation_ids_with_invalid_data: set[int]
+
+    @model_validator(mode="after")
+    def check_ports_unique(self) -> Self:
+        """Check that requirers define unique ports.
+
+        Returns:
+            The validated model, with invalid relation IDs updated in
+                `self.relation_ids_with_invalid_data`
+        """
+        # Maybe the logic here can be optimized, we want to keep track of
+        # the relation IDs that request overlapping ports to ignore them during
+        # rendering of the haproxy configuration.
+        relation_ids_per_port: dict[int, list[int]] = defaultdict(list[int])
+        for requirer_data in self.requirers_data:
+            relation_ids_per_port[requirer_data.application_data.port].append(
+                requirer_data.relation_id
+            )
+
+        for relation_ids in relation_ids_per_port.values():
+            if len(relation_ids) > 1:
+                self.relation_ids_with_invalid_data.update(relation_ids)
+        return self
+
+
+class HaproxyRouteTcpDataAvailableEvent(EventBase):
+    """HaproxyRouteDataAvailableEvent custom event.
+
+    This event indicates that the requirers data are available.
+    """
+
+
+class HaproxyRouteTcpDataRemovedEvent(EventBase):
+    """HaproxyRouteDataRemovedEvent custom event.
+
+    This event indicates that one of the endpoints was removed.
+    """
+
+
+class HaproxyRouteTcpProviderEvents(CharmEvents):
+    """List of events for the haproxy-route TCP provider.
+
+    Attributes:
+        data_available: This event indicates that
+            the haproxy-route endpoints are available.
+        data_removed: This event indicates that one of the endpoints was removed.
+    """
+
+    data_available = EventSource(HaproxyRouteTcpDataAvailableEvent)
+    data_removed = EventSource(HaproxyRouteTcpDataRemovedEvent)
+
+
+class HaproxyRouteTcpProvider(Object):
+    """Haproxy-route interface provider implementation.
+
+    Attributes:
+        on: Custom events of the provider.
+        relations: Related appliations.
+    """
+
+    on = HaproxyRouteTcpProviderEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = HAPROXY_ROUTE_TCP_RELATION_NAME,
+        raise_on_validation_error: bool = False,
+    ) -> None:
+        """Initialize the HaproxyRouteProvider.
+
+        Args:
+            charm: The charm that is instantiating the library.
+            relation_name: The name of the relation.
+            raise_on_validation_error: Whether the library should raise
+                HaproxyRouteTcpInvalidRelationDataError when requirer data validation fails.
+                If this is set to True the provider charm needs to also catch and handle the
+                thrown exception.
+        """
+        super().__init__(charm, relation_name)
+
+        self._relation_name = relation_name
+        self.charm = charm
+        self.raise_on_validation_error = raise_on_validation_error
+        on = self.charm.on
+        self.framework.observe(on[self._relation_name].relation_changed, self._configure)
+        self.framework.observe(on[self._relation_name].relation_broken, self._on_endpoint_removed)
+        self.framework.observe(
+            on[self._relation_name].relation_departed, self._on_endpoint_removed
+        )
+
+    @property
+    def relations(self) -> list[Relation]:
+        """The list of Relation instances associated with this endpoint."""
+        return list(self.charm.model.relations[self._relation_name])
+
+    def _configure(self, _event: EventBase) -> None:
+        """Handle relation events."""
+        if relations := self.relations:
+            # Only for data validation
+            _ = self.get_data(relations)
+            self.on.data_available.emit()
+
+    def _on_endpoint_removed(self, _: EventBase) -> None:
+        """Handle relation broken/departed events."""
+        self.on.data_removed.emit()
+
+    def get_data(self, relations: list[Relation]) -> HaproxyRouteTcpRequirersData:
+        """Fetch requirer data.
+
+        Args:
+            relations: A list of Relation instances to fetch data from.
+
+        Raises:
+            HaproxyRouteTcpInvalidRelationDataError: When requirer data validation fails.
+
+        Returns:
+            HaproxyRouteRequirersData: Validated data from all haproxy-route requirers.
+        """
+        requirers_data: list[HaproxyRouteTcpRequirerData] = []
+        relation_ids_with_invalid_data: set[int] = set()
+        for relation in relations:
+            try:
+                application_data = self._get_requirer_application_data(relation)
+                units_data = self._get_requirer_units_data(relation)
+                haproxy_route_tcp_requirer_data = HaproxyRouteTcpRequirerData(
+                    application_data=application_data,
+                    units_data=units_data,
+                    relation_id=relation.id,
+                    application=relation.app.name,
+                )
+                requirers_data.append(haproxy_route_tcp_requirer_data)
+            except DataValidationError as exc:
+                if self.raise_on_validation_error:
+                    logger.error(
+                        "haproxy-route-tcp data validation failed for relation %s: %s",
+                        relation,
+                        str(exc),
+                    )
+                    raise HaproxyRouteTcpInvalidRelationDataError(
+                        f"haproxy-route-tcp data validation failed for relation: {relation}"
+                    ) from exc
+                relation_ids_with_invalid_data.add(relation.id)
+                continue
+        return HaproxyRouteTcpRequirersData(
+            requirers_data=requirers_data,
+            relation_ids_with_invalid_data=relation_ids_with_invalid_data,
+        )
+
+    def _get_requirer_units_data(self, relation: Relation) -> list[TcpRequirerUnitData]:
+        """Fetch and validate the requirer's units data.
+
+        Args:
+            relation: The relation to fetch unit data from.
+
+        Raises:
+            DataValidationError: When unit data validation fails.
+
+        Returns:
+            list[RequirerUnitData]: List of validated unit data from the requirer.
+        """
+        requirer_units_data: list[TcpRequirerUnitData] = []
+
+        for unit in relation.units:
+            databag = relation.data.get(unit)
+            if not databag:
+                logger.error(
+                    "Requirer unit data does not exist even though the unit is still present."
+                )
+                continue
+            try:
+                data = cast(TcpRequirerUnitData, TcpRequirerUnitData.load(databag))
+                requirer_units_data.append(data)
+            except DataValidationError:
+                logger.error("Invalid requirer application data for %s", unit)
+                raise
+        return requirer_units_data
+
+    def _get_requirer_application_data(self, relation: Relation) -> TcpRequirerApplicationData:
+        """Fetch and validate the requirer's application databag.
+
+        Args:
+            relation: The relation to fetch application data from.
+
+        Raises:
+            DataValidationError: When requirer application data validation fails.
+
+        Returns:
+            RequirerApplicationData: Validated application data from the requirer.
+        """
+        try:
+            return cast(
+                TcpRequirerApplicationData,
+                TcpRequirerApplicationData.load(relation.data[relation.app]),
+            )
+        except DataValidationError:
+            logger.error("Invalid requirer application data for %s", relation.app.name)
+            raise
+
+    def publish_proxied_endpoints(self, endpoints: list[str], relation: Relation) -> None:
+        """Publish to the app databag the proxied endpoints.
+
+        Args:
+            endpoints: The list of proxied endpoints to publish.
+            relation: The relation with the requirer application.
+        """
+        HaproxyRouteTcpProviderAppData(
+            endpoints=[cast(AnyUrl, endpoint) for endpoint in endpoints]
+        ).dump(relation.data[self.charm.app], clear=True)
+
+
+class HaproxyRouteTcpEnpointsReadyEvent(EventBase):
+    """HaproxyRouteTcpEnpointsReadyEvent custom event."""
+
+
+class HaproxyRouteTcpEndpointsRemovedEvent(EventBase):
+    """HaproxyRouteTcpEndpointsRemovedEvent custom event."""
+
+
+class HaproxyRouteTcpRequirerEvents(CharmEvents):
+    """List of events that the TLS Certificates requirer charm can leverage.
+
+    Attributes:
+        ready: when the provider proxied endpoints are ready.
+        removed: when the provider
+    """
+
+    ready = EventSource(HaproxyRouteTcpEnpointsReadyEvent)
+    removed = EventSource(HaproxyRouteTcpEndpointsRemovedEvent)
+
+
+class HaproxyRouteTcpRequirer(Object):
+    """haproxy-route interface requirer implementation.
+
+    Attributes:
+        on: Custom events of the requirer.
+    """
+
+    on = HaproxyRouteTcpRequirerEvents()
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        *,
+        port: Optional[int] = None,
+        backend_port: Optional[int] = None,
+        hosts: Optional[list[str]] = None,
+        sni: Optional[str] = None,
+        check_interval: Optional[int] = None,
+        check_rise: Optional[int] = None,
+        check_fall: Optional[int] = None,
+        check_type: Optional[TCPHealthCheckType] = None,
+        check_send: Optional[str] = None,
+        check_expect: Optional[str] = None,
+        check_db_user: Optional[str] = None,
+        load_balancing_algorithm: Optional[LoadBalancingAlgorithm] = None,
+        load_balancing_consistent_hashing: bool = False,
+        rate_limit_connections_per_minute: Optional[int] = None,
+        rate_limit_policy: TCPRateLimitPolicy = TCPRateLimitPolicy.REJECT,
+        upload_limit: Optional[int] = None,
+        download_limit: Optional[int] = None,
+        retry_count: Optional[int] = None,
+        retry_redispatch: bool = False,
+        server_timeout: Optional[int] = None,
+        connect_timeout: Optional[int] = None,
+        queue_timeout: Optional[int] = None,
+        server_maxconn: Optional[int] = None,
+        ip_deny_list: Optional[list[IPvAnyAddress]] = None,
+        enforce_tls: bool = True,
+        tls_terminate: bool = True,
+        unit_address: Optional[str] = None,
+    ) -> None:
+        """Initialize the HaproxyRouteRequirer.
+
+        Args:
+            charm: The charm that is instantiating the library.
+            relation_name: The name of the relation to bind to.
+            port: The provider port.
+            backend_port: List of ports the service is listening on.
+            hosts: List of backend server addresses. Currently only support IP addresses.
+            sni: List of URL paths to route to this service.
+            check_interval: Interval between health checks in seconds.
+            check_rise: Number of successful health checks before server is considered up.
+            check_fall: Number of failed health checks before server is considered down.
+            check_type: Health check type,
+                Can be “generic”, “mysql”, “postgres”, “redis” or “smtp”.
+            check_send: Only used in generic health checks,
+                specify a string to send in the health check request.
+            check_expect: Only used in generic health checks,
+                specify the expected response from a health check request.
+            check_db_user: Only used if type is postgres or mysql,
+                specify the user name to enable HAproxy to send a Client Authentication packet.
+            load_balancing_algorithm: Algorithm to use for load balancing.
+            load_balancing_consistent_hashing: Whether to use consistent hashing.
+            rate_limit_connections_per_minute: Maximum connections allowed per minute.
+            rate_limit_policy: Policy to apply when rate limit is reached.
+            upload_limit: Maximum upload bandwidth in bytes per second.
+            download_limit: Maximum download bandwidth in bytes per second.
+            retry_count: Number of times to retry failed requests.
+            retry_redispatch: Whether to redispatch failed requests to another server.
+            server_timeout: Timeout for requests from haproxy to backend servers in seconds.
+            connect_timeout: Timeout for client requests to haproxy in seconds.
+            queue_timeout: Timeout for requests waiting in queue in seconds.
+            server_maxconn: Maximum connections per server.
+            ip_deny_list: List of source IP addresses to block.
+            enforce_tls: Whether to enforce TLS for all traffic coming to the backend.
+            tls_terminate: Whether to enable tls termination on the dedicated frontend.
+            unit_address: IP address of the unit (if not provided, will use binding address).
+        """
+        super().__init__(charm, relation_name)
+
+        self._relation_name = relation_name
+        self.relation = self.model.get_relation(self._relation_name)
+        self.charm = charm
+        self.app = self.charm.app
+
+        # build the full application data
+        self._application_data = self._generate_application_data(
+            port=port,
+            backend_port=backend_port,
+            hosts=hosts,
+            sni=sni,
+            check_interval=check_interval,
+            check_rise=check_rise,
+            check_fall=check_fall,
+            check_type=check_type,
+            check_send=check_send,
+            check_expect=check_expect,
+            check_db_user=check_db_user,
+            load_balancing_algorithm=load_balancing_algorithm,
+            load_balancing_consistent_hashing=load_balancing_consistent_hashing,
+            rate_limit_connections_per_minute=rate_limit_connections_per_minute,
+            rate_limit_policy=rate_limit_policy,
+            upload_limit=upload_limit,
+            download_limit=download_limit,
+            retry_count=retry_count,
+            retry_redispatch=retry_redispatch,
+            server_timeout=server_timeout,
+            connect_timeout=connect_timeout,
+            queue_timeout=queue_timeout,
+            server_maxconn=server_maxconn,
+            ip_deny_list=ip_deny_list,
+            enforce_tls=enforce_tls,
+            tls_terminate=tls_terminate,
+        )
+        self._unit_address = unit_address
+
+        on = self.charm.on
+        self.framework.observe(on[self._relation_name].relation_created, self._configure)
+        self.framework.observe(on[self._relation_name].relation_changed, self._configure)
+        self.framework.observe(on[self._relation_name].relation_broken, self._on_relation_broken)
+
+    def _configure(self, _: EventBase) -> None:
+        """Handle relation events."""
+        self.update_relation_data()
+        if self.relation and self.get_proxied_endpoints():
+            # This event is only emitted when the provider databag changes
+            # which only happens when relevant changes happened
+            # Additionally this event is purely informational and it's up to the requirer to
+            # fetch the proxied endpoints in their code using get_proxied_endpoints
+            self.on.ready.emit()
+
+    def _on_relation_broken(self, _: RelationBrokenEvent) -> None:
+        """Handle relation broken event."""
+        self.on.removed.emit()
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def provide_haproxy_route_tcp_requirements(
+        self,
+        *,
+        port: int,
+        backend_port: Optional[int] = None,
+        hosts: Optional[list[str]] = None,
+        sni: Optional[str] = None,
+        check_interval: Optional[int] = None,
+        check_rise: Optional[int] = None,
+        check_fall: Optional[int] = None,
+        check_type: Optional[TCPHealthCheckType] = None,
+        check_send: Optional[str] = None,
+        check_expect: Optional[str] = None,
+        check_db_user: Optional[str] = None,
+        load_balancing_algorithm: Optional[LoadBalancingAlgorithm] = None,
+        load_balancing_consistent_hashing: bool = False,
+        rate_limit_connections_per_minute: Optional[int] = None,
+        rate_limit_policy: TCPRateLimitPolicy = TCPRateLimitPolicy.REJECT,
+        upload_limit: Optional[int] = None,
+        download_limit: Optional[int] = None,
+        retry_count: Optional[int] = None,
+        retry_redispatch: bool = False,
+        server_timeout: Optional[int] = None,
+        connect_timeout: Optional[int] = None,
+        queue_timeout: Optional[int] = None,
+        server_maxconn: Optional[int] = None,
+        ip_deny_list: Optional[list[IPvAnyAddress]] = None,
+        enforce_tls: bool = True,
+        tls_terminate: bool = True,
+        unit_address: Optional[str] = None,
+    ) -> None:
+        """Update haproxy-route requirements data in the relation.
+
+        Args:
+            port: The provider port.
+            backend_port: List of ports the service is listening on.
+            hosts: List of backend server addresses. Currently only support IP addresses.
+            sni: List of URL paths to route to this service.
+            check_interval: Interval between health checks in seconds.
+            check_rise: Number of successful health checks before server is considered up.
+            check_fall: Number of failed health checks before server is considered down.
+            check_type: Health check type,
+                Can be “generic”, “mysql”, “postgres”, “redis” or “smtp”.
+            check_send: Only used in generic health checks,
+                specify a string to send in the health check request.
+            check_expect: Only used in generic health checks,
+                specify the expected response from a health check request.
+            check_db_user: Only used if type is postgres or mysql,
+                specify the user name to enable HAproxy to send a Client Authentication packet.
+            load_balancing_algorithm: Algorithm to use for load balancing.
+            load_balancing_consistent_hashing: Whether to use consistent hashing.
+            rate_limit_connections_per_minute: Maximum connections allowed per minute.
+            rate_limit_policy: Policy to apply when rate limit is reached.
+            upload_limit: Maximum upload bandwidth in bytes per second.
+            download_limit: Maximum download bandwidth in bytes per second.
+            retry_count: Number of times to retry failed requests.
+            retry_redispatch: Whether to redispatch failed requests to another server.
+            server_timeout: Timeout for requests from haproxy to backend servers in seconds.
+            connect_timeout: Timeout for client requests to haproxy in seconds.
+            queue_timeout: Timeout for requests waiting in queue in seconds.
+            server_maxconn: Maximum connections per server.
+            ip_deny_list: List of source IP addresses to block.
+            enforce_tls: Whether to enforce TLS for all traffic coming to the backend.
+            tls_terminate: Whether to enable tls termination on the dedicated frontend.
+            unit_address: IP address of the unit (if not provided, will use binding address).
+        """
+        self._unit_address = unit_address
+        self._application_data = self._generate_application_data(
+            port=port,
+            backend_port=backend_port,
+            hosts=hosts,
+            sni=sni,
+            check_interval=check_interval,
+            check_rise=check_rise,
+            check_fall=check_fall,
+            check_type=check_type,
+            check_send=check_send,
+            check_expect=check_expect,
+            check_db_user=check_db_user,
+            load_balancing_algorithm=load_balancing_algorithm,
+            load_balancing_consistent_hashing=load_balancing_consistent_hashing,
+            rate_limit_connections_per_minute=rate_limit_connections_per_minute,
+            rate_limit_policy=rate_limit_policy,
+            upload_limit=upload_limit,
+            download_limit=download_limit,
+            retry_count=retry_count,
+            retry_redispatch=retry_redispatch,
+            server_timeout=server_timeout,
+            connect_timeout=connect_timeout,
+            queue_timeout=queue_timeout,
+            server_maxconn=server_maxconn,
+            ip_deny_list=ip_deny_list,
+            enforce_tls=enforce_tls,
+            tls_terminate=tls_terminate,
+        )
+        self.update_relation_data()
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+    def _generate_application_data(
+        self,
+        *,
+        port: Optional[int] = None,
+        backend_port: Optional[int] = None,
+        hosts: Optional[list[str]] = None,
+        sni: Optional[str] = None,
+        check_interval: Optional[int] = None,
+        check_rise: Optional[int] = None,
+        check_fall: Optional[int] = None,
+        check_type: Optional[TCPHealthCheckType] = None,
+        check_send: Optional[str] = None,
+        check_expect: Optional[str] = None,
+        check_db_user: Optional[str] = None,
+        load_balancing_algorithm: Optional[LoadBalancingAlgorithm] = None,
+        load_balancing_consistent_hashing: bool = False,
+        rate_limit_connections_per_minute: Optional[int] = None,
+        rate_limit_policy: TCPRateLimitPolicy = TCPRateLimitPolicy.REJECT,
+        upload_limit: Optional[int] = None,
+        download_limit: Optional[int] = None,
+        retry_count: Optional[int] = None,
+        retry_redispatch: bool = False,
+        server_timeout: Optional[int] = None,
+        connect_timeout: Optional[int] = None,
+        queue_timeout: Optional[int] = None,
+        server_maxconn: Optional[int] = None,
+        ip_deny_list: Optional[list[IPvAnyAddress]] = None,
+        enforce_tls: bool = True,
+        tls_terminate: bool = True,
+    ) -> dict[str, Any]:
+        """Generate the complete application data structure.
+
+        Args:
+            port: The provider port.
+            backend_port: List of ports the service is listening on.
+            hosts: List of backend server addresses. Currently only support IP addresses.
+            sni: List of URL paths to route to this service.
+            check_interval: Interval between health checks in seconds.
+            check_rise: Number of successful health checks before server is considered up.
+            check_fall: Number of failed health checks before server is considered down.
+            check_type: Health check type,
+                Can be “generic”, “mysql”, “postgres”, “redis” or “smtp”.
+            check_send: Only used in generic health checks,
+                specify a string to send in the health check request.
+            check_expect: Only used in generic health checks,
+                specify the expected response from a health check request.
+            check_db_user: Only used if type is postgres or mysql,
+                specify the user name to enable HAproxy to send a Client Authentication packet.
+            load_balancing_algorithm: Algorithm to use for load balancing.
+            load_balancing_consistent_hashing: Whether to use consistent hashing.
+            rate_limit_connections_per_minute: Maximum connections allowed per minute.
+            rate_limit_policy: Policy to apply when rate limit is reached.
+            upload_limit: Maximum upload bandwidth in bytes per second.
+            download_limit: Maximum download bandwidth in bytes per second.
+            retry_count: Number of times to retry failed requests.
+            retry_redispatch: Whether to redispatch failed requests to another server.
+            server_timeout: Timeout for requests from haproxy to backend servers in seconds.
+            connect_timeout: Timeout for client requests to haproxy in seconds.
+            queue_timeout: Timeout for requests waiting in queue in seconds.
+            server_maxconn: Maximum connections per server.
+            ip_deny_list: List of source IP addresses to block.
+            enforce_tls: Whether to enforce TLS for all traffic coming to the backend.
+            tls_terminate: Whether to enable tls termination on the dedicated frontend.
+
+        Returns:
+            dict: A dictionary containing the complete application data structure.
+        """
+        # Apply default value to list parameters to avoid problems with mutable default args.
+        if not hosts:
+            hosts = []
+        if not ip_deny_list:
+            ip_deny_list = []
+
+        application_data: dict[str, Any] = {
+            "port": port,
+            "backend_port": backend_port,
+            "hosts": hosts,
+            "sni": sni,
+            "load_balancing": self._generate_load_balancing_configuration(
+                load_balancing_algorithm, load_balancing_consistent_hashing
+            ),
+            "check": self._generate_server_health_check_configuration(
+                check_interval,
+                check_rise,
+                check_fall,
+                check_type,
+                check_send,
+                check_expect,
+                check_db_user,
+            ),
+            "timeout": self._generate_timeout_configuration(
+                server_timeout, connect_timeout, queue_timeout
+            ),
+            "rate_limit": self._generate_rate_limit_configuration(
+                rate_limit_connections_per_minute, rate_limit_policy
+            ),
+            "bandwidth_limit": {
+                "download": download_limit,
+                "upload": upload_limit,
+            },
+            "retry": self._generate_retry_configuration(retry_count, retry_redispatch),
+            "ip_deny_list": ip_deny_list,
+            "server_maxconn": server_maxconn,
+            "enforce_tls": enforce_tls,
+            "tls_terminate": tls_terminate,
+        }
+
+        return application_data
+
+    def _generate_server_health_check_configuration(
+        self,
+        interval: Optional[int],
+        rise: Optional[int],
+        fall: Optional[int],
+        check_type: Optional[TCPHealthCheckType],
+        send: Optional[str],
+        expect: Optional[str],
+        db_user: Optional[str],
+    ) -> Optional[dict[str, int | str | TCPHealthCheckType | None]]:
+        """Generate configuration for server health checks.
+
+        Args:
+        interval: Number of seconds between consecutive health check attempts.
+        rise: Number of consecutive successful health checks required for up.
+        fall: Number of consecutive failed health checks required for DOWN.
+        check_type: Health check type, Can be “generic”, “mysql”, “postgres”, “redis” or “smtp”.
+        send: Only used in generic health checks,
+            specify a string to send in the health check request.
+        expect: Only used in generic health checks,
+            specify the expected response from a health check request.
+        db_user: Only used if type is postgres or mysql,
+            specify the user name to enable HAproxy to send a Client Authentication packet.
+
+        Returns:
+            Optional[dict[str, int | str | TCPHealthCheckType | None]]:
+                Health check configuration dictionary.
+        """
+        if not (interval and rise and fall):
+            return None
+        return {
+            "interval": interval,
+            "rise": rise,
+            "fall": fall,
+            "check_type": check_type,
+            "send": send,
+            "expect": expect,
+            "db_user": db_user,
+        }
+
+    def _generate_rate_limit_configuration(
+        self,
+        connections_per_minute: Optional[int],
+        policy: TCPRateLimitPolicy,
+    ) -> Optional[dict[str, Any]]:
+        """Generate rate limit configuration.
+
+        Args:
+            connections_per_minute: Maximum connections allowed per minute.
+            policy: Policy to apply when rate limit is reached.
+
+        Returns:
+            Optional[dict[str, Any]]: Rate limit configuration,
+                or None if required fields are not configured.
+        """
+        if not connections_per_minute:
+            return None
+        return {
+            "connections_per_minute": connections_per_minute,
+            "policy": policy,
+        }
+
+    def _generate_timeout_configuration(
+        self,
+        server_timeout_in_seconds: Optional[int],
+        connect_timeout_in_seconds: Optional[int],
+        queue_timeout_in_seconds: Optional[int],
+    ) -> Optional[dict[str, Optional[int]]]:
+        """Generate rate limit configuration.
+
+        Args:
+            server_timeout_in_seconds: Server timeout.
+            connect_timeout_in_seconds: Connect timeout.
+            queue_timeout_in_seconds: Queue timeout
+
+        Returns:
+            Optional[dict[str, Any]]: Rate limit configuration,
+                or None if required fields are not configured.
+        """
+        if not (
+            server_timeout_in_seconds or connect_timeout_in_seconds or queue_timeout_in_seconds
+        ):
+            return None
+        return {
+            "server": server_timeout_in_seconds,
+            "connect": connect_timeout_in_seconds,
+            "queue": queue_timeout_in_seconds,
+        }
+
+    def _generate_retry_configuration(
+        self, count: Optional[int], redispatch: bool
+    ) -> Optional[dict[str, Any]]:
+        """Generate retry configuration.
+
+        Args:
+            count: Number of times to retry failed requests.
+            redispatch: Whether to redispatch failed requests to another server.
+
+        Returns:
+            Optional[dict[str, Any]]: Retry configuration dictionary,
+                or None if required fields are not configured.
+        """
+        if not count:
+            return None
+        return {
+            "count": count,
+            "redispatch": redispatch,
+        }
+
+    def _generate_load_balancing_configuration(
+        self, algorithm: Optional[LoadBalancingAlgorithm], consistent_hashing: bool
+    ) -> Optional[dict[str, Any]]:
+        """Generate load balancing configuration.
+
+        Args:
+            algorithm: The load balancing algorithm.
+            consistent_hashing: Whether to use consistent hashing.
+
+        Returns:
+            Optional[dict[str, Any]]: Load balancing configuration dictionary,
+                or None if required fields are not configured.
+        """
+        if not algorithm:
+            return None
+        return {
+            "algorithm": algorithm,
+            "consistent_hashing": consistent_hashing,
+        }
+
+    def update_relation_data(self) -> None:
+        """Update both application and unit data in the relation."""
+        if not self._application_data.get("port"):
+            logger.warning("port must be set, skipping update.")
+            return
+
+        if relation := self.relation:
+            self._update_application_data(relation)
+            self._update_unit_data(relation)
+
+    def _update_application_data(self, relation: Relation) -> None:
+        """Update application data in the relation databag.
+
+        Args:
+            relation: The relation instance.
+        """
+        if self.charm.unit.is_leader():
+            application_data = self._prepare_application_data()
+            application_data.dump(relation.data[self.app], clear=True)
+
+    def _update_unit_data(self, relation: Relation) -> None:
+        """Prepare and update the unit data in the relation databag.
+
+        Args:
+            relation: The relation instance.
+        """
+        unit_data = self._prepare_unit_data()
+        unit_data.dump(relation.data[self.charm.unit], clear=True)
+
+    def _prepare_application_data(self) -> TcpRequirerApplicationData:
+        """Prepare and validate the application data.
+
+        Raises:
+            DataValidationError: When validation of application data fails.
+
+        Returns:
+            RequirerApplicationData: The validated application data model.
+        """
+        try:
+            return cast(
+                TcpRequirerApplicationData,
+                TcpRequirerApplicationData.from_dict(self._application_data),
+            )
+        except ValidationError as exc:
+            logger.error("Validation error when preparing requirer application data.")
+            raise DataValidationError(
+                "Validation error when preparing requirer application data."
+            ) from exc
+
+    def _prepare_unit_data(self) -> TcpRequirerUnitData:
+        """Prepare and validate unit data.
+
+        Raises:
+            DataValidationError: When no address or unit IP is available.
+
+        Returns:
+            RequirerUnitData: The validated unit data model.
+        """
+        address = self._unit_address
+        if not address:
+            network_binding = self.charm.model.get_binding(self._relation_name)
+            if (
+                network_binding is not None
+                and (bind_address := network_binding.network.bind_address) is not None
+            ):
+                address = str(bind_address)
+            else:
+                logger.error("No unit IP available.")
+                raise DataValidationError("No unit IP available.")
+        return TcpRequirerUnitData(address=cast(IPvAnyAddress, address))
+
+    def get_proxied_endpoints(self) -> list[AnyUrl]:
+        """The full ingress URL to reach the current unit.
+
+        Returns:
+            The provider URL or None if the URL isn't available yet or is not valid.
+        """
+        relation = self.relation
+        if not relation or not relation.app:
+            return []
+
+        # Fetch the provider's app databag
+        try:
+            databag = relation.data[relation.app]
+        except ModelError:
+            logger.exception("Error reading remote app data.")
+            return []
+
+        if not databag:  # not ready yet
+            return []
+
+        try:
+            provider_data = cast(
+                HaproxyRouteTcpProviderAppData, HaproxyRouteTcpProviderAppData.load(databag)
+            )
+            return provider_data.endpoints
+        except DataValidationError:
+            logger.exception("Invalid provider url.")
+            return []
+
+    # The following methods allows for chaining which aims to improve the developper experience
+    # The following methods allows for chaining which aims to improve the developper experience
+    def configure_port(self, port: int) -> "Self":
+        """Set the provider port.
+
+        Args:
+            port: The provider port to set
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        self._application_data["port"] = port
+        return self
+
+    def configure_backend_port(self, backend_port: int) -> "Self":
+        """Set the backend port.
+
+        Args:
+            backend_port: The backend port to set
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        self._application_data["backend_port"] = backend_port
+        return self
+
+    def configure_hosts(self, hosts: Optional[list[int]] = None) -> "Self":
+        """Set backend hosts.
+
+        Args:
+            hosts: The hosts list to set
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        if not hosts:
+            hosts = []
+        self._application_data["hosts"] = hosts
+        return self
+
+    def configure_sni(self, sni: str) -> "Self":
+        """Set the SNI.
+
+        Args:
+            sni: The SNI to set
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        self._application_data["sni"] = sni
+        return self
+
+    def configure_health_check(
+        self,
+        interval: int,
+        rise: int,
+        fall: int,
+        check_type: TCPHealthCheckType = TCPHealthCheckType.GENERIC,
+        send: Optional[str] = None,
+        expect: Optional[str] = None,
+        db_user: Optional[str] = None,
+    ) -> "Self":
+        """Configure server health check.
+
+        Args:
+        interval: Number of seconds between consecutive health check attempts.
+        rise: Number of consecutive successful health checks required for up.
+        fall: Number of consecutive failed health checks required for DOWN.
+        check_type: Health check type, Can be "generic", "mysql", "postgres", "redis" or "smtp".
+        send: Only used in generic health checks,
+            specify a string to send in the health check request.
+        expect: Only used in generic health checks,
+            specify the expected response from a health check request.
+        db_user: Only used if type is postgres or mysql,
+            specify the user name to enable HAproxy to send a Client Authentication packet.
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        self._application_data["check"] = self._generate_server_health_check_configuration(
+            interval,
+            rise,
+            fall,
+            check_type,
+            send,
+            expect,
+            db_user,
+        )
+        return self
+
+    def configure_rate_limit(
+        self,
+        connections_per_minute: int,
+        policy: TCPRateLimitPolicy = TCPRateLimitPolicy.REJECT,
+    ) -> "Self":
+        """Configure rate limit.
+
+        Args:
+            connections_per_minute: The number of connections per minute allowed
+            policy: The rate limit policy to apply
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        self._application_data["rate_limit"] = self._generate_rate_limit_configuration(
+            connections_per_minute, policy
+        )
+        return self
+
+    def configure_bandwidth_limit(
+        self,
+        upload_bytes_per_second: Optional[int] = None,
+        download_bytes_per_second: Optional[int] = None,
+    ) -> "Self":
+        """Configure bandwidth limit.
+
+        Args:
+            upload_bytes_per_second: Upload bandwidth limit in bytes per second
+            download_bytes_per_second: Download bandwidth limit in bytes per second
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        if not upload_bytes_per_second and not download_bytes_per_second:
+            logger.error(
+                "At least one of `upload_bytes_per_second` "
+                "or `upload_bytes_per_second` must be set."
+            )
+            return self
+        self._application_data["bandwidth_limit"] = {
+            "download": download_bytes_per_second,
+            "upload": upload_bytes_per_second,
+        }
+
+        return self
+
+    def configure_retry(
+        self,
+        retry_count: int,
+        retry_redispatch: bool = False,
+    ) -> "Self":
+        """Configure retry.
+
+        Args:
+            retry_count: The number of retries to attempt
+            retry_redispatch: Whether to enable retry redispatch
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        self._application_data["retry"] = self._generate_retry_configuration(
+            retry_count, retry_redispatch
+        )
+        return self
+
+    def configure_timeout(
+        self,
+        server_timeout_in_seconds: Optional[int],
+        connect_timeout_in_seconds: Optional[int],
+        queue_timeout_in_seconds: Optional[int],
+    ) -> "Self":
+        """Configure timeout.
+
+        Args:
+            server_timeout_in_seconds: Server timeout.
+            connect_timeout_in_seconds: Connect timeout.
+            queue_timeout_in_seconds: Queue timeout
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        if not (
+            server_timeout_in_seconds or connect_timeout_in_seconds or queue_timeout_in_seconds
+        ):
+            logger.error(
+                "At least one of `server_timeout_in_seconds`, `connect_timeout_in_seconds` "
+                "or `queue_timeout_in_seconds` must be set."
+            )
+            return self
+        self._application_data["timeout"] = self._generate_timeout_configuration(
+            server_timeout_in_seconds, connect_timeout_in_seconds, queue_timeout_in_seconds
+        )
+        return self
+
+    def configure_server_max_connections(self, max_connections: int) -> "Self":
+        """Set the server max connections.
+
+        Args:
+            max_connections: The number of max connections to set
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        self._application_data["server_maxconn"] = max_connections
+        return self
+
+    def disable_tls_termination(self) -> "Self":
+        """Disable TLS termination.
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        self._application_data["tls_terminate"] = False
+        return self
+
+    def allow_http(self) -> "Self":
+        """Do not enforce TLS.
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        self._application_data["enforce_tls"] = False
+        return self
+
+    def configure_deny_list(self, ip_deny_list: Optional[list[IPvAnyAddress]] = None) -> "Self":
+        """Configure IP deny list.
+
+        Args:
+            ip_deny_list: List of IP addresses to deny
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        if not ip_deny_list:
+            ip_deny_list = []
+        self._application_data["ip_deny_list"] = False
+        return self

--- a/maas-region/lib/charms/haproxy/v1/haproxy_route_tcp.py
+++ b/maas-region/lib/charms/haproxy/v1/haproxy_route_tcp.py
@@ -186,7 +186,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_TCP_RELATION_NAME = "haproxy-route-tcp"
@@ -976,7 +976,7 @@ class HaproxyRouteTcpRequirer(Object):
         *,
         port: Optional[int] = None,
         backend_port: Optional[int] = None,
-        hosts: Optional[list[str]] = None,
+        hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
         check_interval: Optional[int] = None,
         check_rise: Optional[int] = None,
@@ -1102,7 +1102,7 @@ class HaproxyRouteTcpRequirer(Object):
         *,
         port: int,
         backend_port: Optional[int] = None,
-        hosts: Optional[list[str]] = None,
+        hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
         check_interval: Optional[int] = None,
         check_rise: Optional[int] = None,
@@ -1200,7 +1200,7 @@ class HaproxyRouteTcpRequirer(Object):
         *,
         port: Optional[int] = None,
         backend_port: Optional[int] = None,
-        hosts: Optional[list[str]] = None,
+        hosts: Optional[list[IPvAnyAddress]] = None,
         sni: Optional[str] = None,
         check_interval: Optional[int] = None,
         check_rise: Optional[int] = None,
@@ -1558,7 +1558,7 @@ class HaproxyRouteTcpRequirer(Object):
         self._application_data["backend_port"] = backend_port
         return self
 
-    def configure_hosts(self, hosts: Optional[list[int]] = None) -> "Self":
+    def configure_hosts(self, hosts: Optional[list[IPvAnyAddress]] = None) -> "Self":
         """Set backend hosts.
 
         Args:

--- a/maas-region/lib/charms/haproxy/v1/haproxy_route_tcp.py
+++ b/maas-region/lib/charms/haproxy/v1/haproxy_route_tcp.py
@@ -10,6 +10,18 @@ cd some-charm
 charmcraft fetch-lib charms.haproxy.v1.haproxy_route_tcp
 ```
 
+### Dependencies
+
+This library requires the `validators` Python package for domain validation.
+Add it to your charm's dependencies in `charmcraft.yaml`:
+
+```yaml
+parts:
+  charm:
+    charm-python-packages:
+      - validators
+```
+
 In the `metadata.yaml` of the charm, add the following:
 
 ```yaml
@@ -22,7 +34,7 @@ requires:
 Then, to initialise the library:
 
 ```python
-from charms.haproxy.v0.haproxy_route_tcp import HaproxyRouteTcpRequirer
+from charms.haproxy.v1.haproxy_route_tcp import HaproxyRouteTcpRequirer
 
 class SomeCharm(CharmBase):
   def __init__(self, *args):
@@ -122,7 +134,7 @@ Note that this interface supports relating to multiple endpoints.
 
 Then, to initialise the library:
 ```python
-from charms.haproxy.v0.haproxy_route import HaproxyRouteTcpProvider
+from charms.haproxy.v1.haproxy_route_tcp import HaproxyRouteTcpProvider
 
 class SomeCharm(CharmBase):
     self.haproxy_route_tcp_provider = HaproxyRouteTcpProvider(self)
@@ -154,7 +166,6 @@ from ops.charm import CharmEvents
 from ops.framework import EventBase, EventSource, Object
 from ops.model import Relation
 from pydantic import (
-    AnyUrl,
     BaseModel,
     BeforeValidator,
     ConfigDict,
@@ -165,16 +176,17 @@ from pydantic import (
 )
 from pydantic.dataclasses import dataclass
 from typing_extensions import Self
+from validators import domain
 
 # The unique Charmhub library identifier, never change it
 LIBID = "b1b5c0a6f1b5481c9923efa042846681"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 1
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_TCP_RELATION_NAME = "haproxy-route-tcp"
@@ -198,6 +210,27 @@ def value_contains_invalid_characters(value: Optional[str]) -> Optional[str]:
 
     if [char for char in value if char in HAPROXY_CONFIG_INVALID_CHARACTERS]:
         raise ValueError(f"Relation data contains invalid character(s) {value}")
+    return value
+
+
+def valid_domain_with_wildcard(value: str) -> str:
+    """Validate if value is a valid domain that can include a wildcard.
+
+    The wildcard character (*) can't be at the TLD level, for example *.com is not valid.
+    This is supported natively by the library ( e.g domain("com") will raise a ValidationError ).
+
+    Raises:
+        ValueError: When value is not a valid domain.
+
+    Args:
+        value: The value to validate.
+
+    Returns:
+        The validated value.
+    """
+    fqdn = value[2:] if value.startswith("*.") else value
+    if not bool(domain(fqdn)):
+        raise ValueError(f"Invalid domain: {value}")
     return value
 
 
@@ -581,10 +614,10 @@ class TcpRequirerApplicationData(_DatabagModel):
         gt=0,
         le=65525,
     )
-    sni: Optional[VALIDSTR] = Field(
+    sni: Optional[Annotated[VALIDSTR, BeforeValidator(valid_domain_with_wildcard)]] = Field(
         description=(
             "Server name identification. Used to route traffic to the service. "
-            "Only available if TLS is enabled."
+            "Only available if TLS is enabled. Supports wildcard domains (e.g., *.example.com)."
         ),
         default=None,
     )
@@ -656,7 +689,7 @@ class HaproxyRouteTcpProviderAppData(_DatabagModel):
         endpoints: The list of proxied endpoints that maps to the backend.
     """
 
-    endpoints: list[AnyUrl]
+    endpoints: list[str]
 
 
 class TcpRequirerUnitData(_DatabagModel):
@@ -901,17 +934,17 @@ class HaproxyRouteTcpProvider(Object):
             endpoints: The list of proxied endpoints to publish.
             relation: The relation with the requirer application.
         """
-        HaproxyRouteTcpProviderAppData(
-            endpoints=[cast(AnyUrl, endpoint) for endpoint in endpoints]
-        ).dump(relation.data[self.charm.app], clear=True)
+        HaproxyRouteTcpProviderAppData(endpoints=endpoints).dump(
+            relation.data[self.charm.app], clear=True
+        )
 
 
 class HaproxyRouteTcpEnpointsReadyEvent(EventBase):
     """HaproxyRouteTcpEnpointsReadyEvent custom event."""
 
 
-class HaproxyRouteTcpEndpointsRemovedEvent(EventBase):
-    """HaproxyRouteTcpEndpointsRemovedEvent custom event."""
+class HAProxyRouteTcpBackendsRemovedEvent(EventBase):
+    """HAProxyRouteTcpBackendsRemovedEvent custom event."""
 
 
 class HaproxyRouteTcpRequirerEvents(CharmEvents):
@@ -923,7 +956,7 @@ class HaproxyRouteTcpRequirerEvents(CharmEvents):
     """
 
     ready = EventSource(HaproxyRouteTcpEnpointsReadyEvent)
-    removed = EventSource(HaproxyRouteTcpEndpointsRemovedEvent)
+    removed = EventSource(HAProxyRouteTcpBackendsRemovedEvent)
 
 
 class HaproxyRouteTcpRequirer(Object):
@@ -1471,7 +1504,7 @@ class HaproxyRouteTcpRequirer(Object):
                 raise DataValidationError("No unit IP available.")
         return TcpRequirerUnitData(address=cast(IPvAnyAddress, address))
 
-    def get_proxied_endpoints(self) -> list[AnyUrl]:
+    def get_proxied_endpoints(self) -> list[str]:
         """The full ingress URL to reach the current unit.
 
         Returns:
@@ -1500,8 +1533,7 @@ class HaproxyRouteTcpRequirer(Object):
             logger.exception("Invalid provider url.")
             return []
 
-    # The following methods allows for chaining which aims to improve the developper experience
-    # The following methods allows for chaining which aims to improve the developper experience
+    # The following methods allow for chaining which aims to improve the developer experience
     def configure_port(self, port: int) -> "Self":
         """Set the provider port.
 
@@ -1626,7 +1658,7 @@ class HaproxyRouteTcpRequirer(Object):
         if not upload_bytes_per_second and not download_bytes_per_second:
             logger.error(
                 "At least one of `upload_bytes_per_second` "
-                "or `upload_bytes_per_second` must be set."
+                "or `download_bytes_per_second` must be set."
             )
             return self
         self._application_data["bandwidth_limit"] = {
@@ -1725,5 +1757,5 @@ class HaproxyRouteTcpRequirer(Object):
         """
         if not ip_deny_list:
             ip_deny_list = []
-        self._application_data["ip_deny_list"] = False
+        self._application_data["ip_deny_list"] = ip_deny_list
         return self

--- a/maas-region/lib/charms/haproxy/v1/haproxy_route_tcp.py
+++ b/maas-region/lib/charms/haproxy/v1/haproxy_route_tcp.py
@@ -186,7 +186,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_TCP_RELATION_NAME = "haproxy-route-tcp"
@@ -603,6 +603,7 @@ class TcpRequirerApplicationData(_DatabagModel):
         ip_deny_list: List of source IP addresses to block.
         enforce_tls: Whether to enforce TLS for all traffic coming to the backend.
         tls_terminate: Whether to enable tls termination on the dedicated frontend.
+        proxy_protocol: Whether to enable PROXY protocol when connecting to backend servers.
     """
 
     port: int = Field(description="The port exposed on the provider.", gt=0, le=65535)
@@ -653,6 +654,10 @@ class TcpRequirerApplicationData(_DatabagModel):
     )
     enforce_tls: bool = Field(description="Whether to enforce TLS for all traffic.", default=True)
     tls_terminate: bool = Field(description="Whether to enable tls termination.", default=True)
+    proxy_protocol: bool = Field(
+        description="Whether to enable PROXY protocol when connecting to backend servers.",
+        default=False,
+    )
 
     @model_validator(mode="after")
     def assign_default_backend_port(self) -> "Self":
@@ -1000,6 +1005,7 @@ class HaproxyRouteTcpRequirer(Object):
         ip_deny_list: Optional[list[IPvAnyAddress]] = None,
         enforce_tls: bool = True,
         tls_terminate: bool = True,
+        proxy_protocol: bool = False,
         unit_address: Optional[str] = None,
     ) -> None:
         """Initialize the HaproxyRouteRequirer.
@@ -1037,6 +1043,7 @@ class HaproxyRouteTcpRequirer(Object):
             ip_deny_list: List of source IP addresses to block.
             enforce_tls: Whether to enforce TLS for all traffic coming to the backend.
             tls_terminate: Whether to enable tls termination on the dedicated frontend.
+            proxy_protocol: Whether to enable PROXY protocol when connecting to backend servers.
             unit_address: IP address of the unit (if not provided, will use binding address).
         """
         super().__init__(charm, relation_name)
@@ -1074,6 +1081,7 @@ class HaproxyRouteTcpRequirer(Object):
             ip_deny_list=ip_deny_list,
             enforce_tls=enforce_tls,
             tls_terminate=tls_terminate,
+            proxy_protocol=proxy_protocol,
         )
         self._unit_address = unit_address
 
@@ -1126,6 +1134,7 @@ class HaproxyRouteTcpRequirer(Object):
         ip_deny_list: Optional[list[IPvAnyAddress]] = None,
         enforce_tls: bool = True,
         tls_terminate: bool = True,
+        proxy_protocol: bool = False,
         unit_address: Optional[str] = None,
     ) -> None:
         """Update haproxy-route requirements data in the relation.
@@ -1161,6 +1170,7 @@ class HaproxyRouteTcpRequirer(Object):
             ip_deny_list: List of source IP addresses to block.
             enforce_tls: Whether to enforce TLS for all traffic coming to the backend.
             tls_terminate: Whether to enable tls termination on the dedicated frontend.
+            proxy_protocol: Whether to enable PROXY protocol when connecting to backend servers.
             unit_address: IP address of the unit (if not provided, will use binding address).
         """
         self._unit_address = unit_address
@@ -1191,6 +1201,7 @@ class HaproxyRouteTcpRequirer(Object):
             ip_deny_list=ip_deny_list,
             enforce_tls=enforce_tls,
             tls_terminate=tls_terminate,
+            proxy_protocol=proxy_protocol,
         )
         self.update_relation_data()
 
@@ -1224,6 +1235,7 @@ class HaproxyRouteTcpRequirer(Object):
         ip_deny_list: Optional[list[IPvAnyAddress]] = None,
         enforce_tls: bool = True,
         tls_terminate: bool = True,
+        proxy_protocol: bool = False,
     ) -> dict[str, Any]:
         """Generate the complete application data structure.
 
@@ -1258,6 +1270,7 @@ class HaproxyRouteTcpRequirer(Object):
             ip_deny_list: List of source IP addresses to block.
             enforce_tls: Whether to enforce TLS for all traffic coming to the backend.
             tls_terminate: Whether to enable tls termination on the dedicated frontend.
+            proxy_protocol: Whether to enable PROXY protocol when connecting to backend servers.
 
         Returns:
             dict: A dictionary containing the complete application data structure.
@@ -1300,6 +1313,7 @@ class HaproxyRouteTcpRequirer(Object):
             "server_maxconn": server_maxconn,
             "enforce_tls": enforce_tls,
             "tls_terminate": tls_terminate,
+            "proxy_protocol": proxy_protocol,
         }
 
         return application_data
@@ -1758,4 +1772,13 @@ class HaproxyRouteTcpRequirer(Object):
         if not ip_deny_list:
             ip_deny_list = []
         self._application_data["ip_deny_list"] = ip_deny_list
+        return self
+
+    def enable_proxy_protocol(self) -> "Self":
+        """Enable PROXY protocol when connecting to backend servers.
+
+        Returns:
+            Self: The HaproxyRouteTcpRequirer class
+        """
+        self._application_data["proxy_protocol"] = True
         return self

--- a/maas-region/lib/charms/rolling_ops/v0/rollingops.py
+++ b/maas-region/lib/charms/rolling_ops/v0/rollingops.py
@@ -89,7 +89,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 
 class LockNoRelationError(Exception):
@@ -301,6 +301,11 @@ class RollingOpsManager(Object):
             callback: a closure to run when we have a lock. (It must take a CharmBase object and
                 EventBase object as args.)
         """
+        logger.warning(
+            "The 'rollingops' v0 library is deprecated and no longer maintained. "
+            "Please migrate to the new implementation: "
+            "https://github.com/canonical/charmlibs/tree/main/rollingops"
+        )
         # "Inherit" from the charm's class. This gives us access to the framework as
         # self.framework, as well as the self.model shortcut.
         super().__init__(charm, None)

--- a/maas-region/pyproject.toml
+++ b/maas-region/pyproject.toml
@@ -1,5 +1,4 @@
 # Linting tools configuration
-
 [tool.ruff]
 target-version = "py310"
 line-length = 99
@@ -47,7 +46,6 @@ ini_options.filterwarnings = [
 
 [tool.coverage]
 # Formatting tools configuration
-
 run.branch = true
 report.show_missing = true
 

--- a/maas-region/pyproject.toml
+++ b/maas-region/pyproject.toml
@@ -36,6 +36,9 @@ lint.mccabe.max-complexity = 10
 [tool.codespell]
 skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
+[tool.pyright]
+include = [ "src/**.py" ]
+
 [tool.pytest]
 ini_options.minversion = "6.0"
 ini_options.log_cli_level = "INFO"
@@ -48,6 +51,3 @@ ini_options.filterwarnings = [
 # Formatting tools configuration
 run.branch = true
 report.show_missing = true
-
-[tool.pyright]
-include = [ "src/**.py" ]

--- a/maas-region/requirements.txt
+++ b/maas-region/requirements.txt
@@ -8,6 +8,8 @@ boto3 >=1.42.21, <1.43.0
 botocore >=1.42.21, <1.43.0
 
 # For Grafana agent
-pydantic < 2
 cosl
 opentelemetry-exporter-otlp-proto-http>=1.21.0
+
+# The smallest Pydantic version that satisfies the `haproxy.v0.haproxy_route_tcp` library (HAProxy charm uses `2.12.5`)
+pydantic==2.12.5

--- a/maas-region/requirements.txt
+++ b/maas-region/requirements.txt
@@ -13,5 +13,5 @@ opentelemetry-exporter-otlp-proto-http>=1.21.0
 
 # For HAProxy integration
 # The smallest Pydantic version that satisfies the `haproxy.v1.haproxy_route_tcp` library (HAProxy charm uses `2.12.5`)
-pydantic==2.13.3
+pydantic==2.13.4
 validators>=0.35.0

--- a/maas-region/requirements.txt
+++ b/maas-region/requirements.txt
@@ -13,5 +13,5 @@ opentelemetry-exporter-otlp-proto-http>=1.21.0
 
 # For HAProxy integration
 # The smallest Pydantic version that satisfies the `haproxy.v1.haproxy_route_tcp` library (HAProxy charm uses `2.12.5`)
-pydantic==2.12.5
+pydantic==2.13.3
 validators>=0.35.0

--- a/maas-region/requirements.txt
+++ b/maas-region/requirements.txt
@@ -11,5 +11,7 @@ botocore >=1.42.21, <1.43.0
 cosl
 opentelemetry-exporter-otlp-proto-http>=1.21.0
 
-# The smallest Pydantic version that satisfies the `haproxy.v0.haproxy_route_tcp` library (HAProxy charm uses `2.12.5`)
+# For HAProxy integration
+# The smallest Pydantic version that satisfies the `haproxy.v1.haproxy_route_tcp` library (HAProxy charm uses `2.12.5`)
 pydantic==2.12.5
+validators>=0.35.0

--- a/maas-region/requirements.txt
+++ b/maas-region/requirements.txt
@@ -4,8 +4,8 @@ tenacity ~=9.1
 # For backup support
 # Botocore and boto3 are updated frequently, so an upper bound is required to allow
 # the latest point release to be installed without the need for many charm releases.
-boto3 >=1.42.21, <1.43.0
-botocore >=1.42.21, <1.43.0
+boto3 >=1.43.11, <1.44.0
+botocore >=1.43.11, <1.44.0
 
 # For Grafana agent
 cosl

--- a/maas-region/src/backups.py
+++ b/maas-region/src/backups.py
@@ -402,7 +402,7 @@ class MAASBackups(Object):
                 for common_prefix in page.get("CommonPrefixes", []):
                     backups.append(
                         common_prefix["Prefix"]
-                        .lstrip(f"{s3_parameters['path'].lstrip('/')}/backup/")
+                        .removeprefix(f"{s3_parameters['path'].lstrip('/')}/backup/")
                         .rstrip("/")
                     )
 

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -15,7 +15,7 @@ from typing import Any
 import ops
 from charms.data_platform_libs.v0 import data_interfaces as db
 from charms.grafana_agent.v0 import cos_agent
-from charms.haproxy.v0.haproxy_route_tcp import HaproxyRouteTcpRequirer, LoadBalancingAlgorithm
+from charms.haproxy.v1.haproxy_route_tcp import HaproxyRouteTcpRequirer, LoadBalancingAlgorithm
 from charms.maas_site_manager_k8s.v0 import enroll
 from charms.operator_libs_linux.v2.snap import SnapError
 from charms.rolling_ops.v0.rollingops import RollingOpsManager, RunWithLock
@@ -165,12 +165,8 @@ class MaasRegionCharm(ops.CharmBase):
             backend_port=MAAS_HTTPS_PORT,
             **COMMON_DEFAULT_HAPROXY_ARGS,
         )
-        self.framework.observe(
-            self.haproxy_tls_route.on.ready, self._reconcile_ha_proxy_and_initialise
-        )
-        self.framework.observe(
-            self.haproxy_tls_route.on.removed, self._reconcile_ha_proxy_and_initialise
-        )
+        self.framework.observe(self.haproxy_tls_route.on.ready, self._reconcile_ha_proxy)
+        self.framework.observe(self.haproxy_tls_route.on.removed, self._reconcile_ha_proxy)
 
         # COS
         endpoints: list[cos_agent._MetricsEndpointDict] = [
@@ -394,6 +390,7 @@ class MaasRegionCharm(ops.CharmBase):
     def _initialize_maas(self) -> bool:
         try:
             self._setup_network()
+            MaasHelper.stop()
             MaasHelper.setup_region(
                 self.maas_api_url,
                 self.connection_string,
@@ -470,27 +467,24 @@ class MaasRegionCharm(ops.CharmBase):
             return
 
         if haproxy_non_tls_enabled:
-            self.haproxy_non_tls_route.provide_haproxy_route_tcp_requirements(
-                port=80, hosts=self.maas_ips, **COMMON_DEFAULT_HAPROXY_ARGS
-            )
+            # TODO: Remove type: ignore when hosts annotation is fixed: https://github.com/canonical/haproxy-operator/pull/383
+            self.haproxy_non_tls_route.configure_hosts(self.maas_ips)  # type: ignore[arg-type]
+            self.haproxy_non_tls_route.update_relation_data()
 
         if haproxy_tls_enabled:
             if haproxy_non_tls_enabled and self.is_tls_config_enabled:
-                self.haproxy_tls_route.provide_haproxy_route_tcp_requirements(
-                    port=443, hosts=self.maas_ips, **COMMON_DEFAULT_HAPROXY_ARGS
-                )
+                # TODO: Remove type: ignore when hosts annotation is fixed: https://github.com/canonical/haproxy-operator/pull/383
+                self.haproxy_tls_route.configure_hosts(self.maas_ips)  # type: ignore[arg-type]
             else:
-                self.haproxy_tls_route.provide_haproxy_route_tcp_requirements(
-                    port=443, hosts=[], **COMMON_DEFAULT_HAPROXY_ARGS
-                )
-
+                self.haproxy_tls_route.configure_hosts()
+            self.haproxy_tls_route.update_relation_data()
         if unit_valid:
             self.unit.status = ops.ActiveStatus()
 
     def _reconcile_ha_proxy_and_initialise(self, event: ops.EventBase) -> None:
         self._reconcile_ha_proxy(event)
         if self.connection_string and (
-            MaasHelper.get_maas_details().get("maas_url") != self.maas_cli_url
+            MaasHelper.get_maas_details().get("maas_url") != self.maas_api_url
         ):
             self._initialize_maas()
 
@@ -509,7 +503,7 @@ class MaasRegionCharm(ops.CharmBase):
                 MaasHelper.disable_tls()
 
     def _update_prometheus_config(self, enable: bool) -> None:
-        if not MaasHelper.is_maas_initialised():
+        if not MaasHelper.is_maas_initialized():
             logger.warning("MAAS Not ready for Prometheus config yet")
             return
 
@@ -666,7 +660,7 @@ class MaasRegionCharm(ops.CharmBase):
 
     def _on_get_api_endpoint_action(self, event: ops.ActionEvent):
         """Handle the get-api-endpoint action."""
-        if url := self.maas_api_url:
+        if url := self.maas_cli_url:
             event.set_results({"api-url": url})
         else:
             event.fail("MAAS is not initialized yet")
@@ -689,17 +683,16 @@ class MaasRegionCharm(ops.CharmBase):
                 )
         self._reconcile_ha_proxy(event)
         maas_details = MaasHelper.get_maas_details()
-        # the MAAS initialisation details have changed
+        # the MAAS initialization details have changed
         init_details = {
-            "API URL": self.connection_string
-            and maas_details.get("maas_url") != self.maas_cli_url,
+            "API URL": maas_details.get("maas_url") != self.maas_api_url,
             f"Mode ({self.get_operational_mode()})": MaasHelper.get_maas_mode()
             != self.get_operational_mode(),
         }
-        if any(init_details.values()):
+        if self.connection_string and any(init_details.values()):
             changes = [k for k, v in init_details.items() if v]
             self.unit.status = ops.MaintenanceStatus(
-                f"re-initialising maas with new: {', '.join(changes)}..."
+                f"re-initializing MAAS with new: {', '.join(changes)}..."
             )
             self._initialize_maas()
 

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -12,6 +12,7 @@ import string
 import subprocess
 from ipaddress import ip_address
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 import ops
 from charms.data_platform_libs.v0 import data_interfaces as db
@@ -306,18 +307,22 @@ class MaasRegionCharm(ops.CharmBase):
         if maas_url := self.config["maas_url"]:
             return str(maas_url)
 
-        scheme, port, proxy_port = (
-            ("https", MAAS_HTTPS_PORT, MAAS_TLS_PROXY_PORT)
+        scheme, port, relation_name = (
+            ("https", MAAS_HTTPS_PORT, HAPROXY_TLS)
             if self.is_tls_config_enabled
-            else ("http", MAAS_HTTP_PORT, MAAS_PROXY_PORT)
+            else ("http", MAAS_HTTP_PORT, HAPROXY_NON_TLS)
         )
 
         # TODO: Read the vip from HAProxy, if the relation exists, once
         # https://github.com/canonical/haproxy-operator/issues/365 or similar is implemented
-        if relation := self.model.get_relation(HAPROXY_NON_TLS):
-            unit = next(iter(relation.units), None)
-            if unit and (addr := relation.data[unit].get("public-address")):
-                return f"{scheme}://{addr}:{proxy_port}/MAAS"
+        if relation := self.model.get_relation(relation_name):
+            if endpoints := relation.data[relation.app].get("endpoints"):
+                try:
+                    endpoint_list = json.loads(endpoints)
+                    if isinstance(endpoint_list, list) and endpoint_list:
+                        return f"{scheme}://{endpoint_list[0]}/MAAS"
+                except json.JSONDecodeError:
+                    logger.warning(f"Invalid endpoints format from HAProxy: {endpoints}")
         return f"{scheme}://{self.bind_address}:{port}/MAAS"
 
     @property
@@ -328,14 +333,22 @@ class MaasRegionCharm(ops.CharmBase):
             str: The API URL
         """
         if maas_url := self.config["maas_url"]:
-            return str(maas_url)
+            parsed = urlparse(str(maas_url))
+            # Force http scheme for internal API initialization
+            if parsed.scheme == "https":
+                parsed = parsed._replace(scheme="http")
+            return urlunparse(parsed)
 
         # TODO: Read the vip from HAProxy, if the relation exists, once
         # https://github.com/canonical/haproxy-operator/issues/365 or similar is implemented
         if relation := self.model.get_relation(HAPROXY_NON_TLS):
-            unit = next(iter(relation.units), None)
-            if unit and (addr := relation.data[unit].get("public-address")):
-                return f"http://{addr}:{MAAS_PROXY_PORT}/MAAS"
+            if endpoints := relation.data[relation.app].get("endpoints"):
+                try:
+                    endpoint_list = json.loads(endpoints)
+                    if isinstance(endpoint_list, list) and endpoint_list:
+                        return f"http://{endpoint_list[0]}/MAAS"
+                except json.JSONDecodeError:
+                    logger.warning(f"Invalid endpoints format from HAProxy: {endpoints}")
         return f"http://{self.bind_address}:{MAAS_HTTP_PORT}/MAAS"
 
     @property
@@ -773,6 +786,14 @@ class MaasRegionCharm(ops.CharmBase):
             if not cert or not key:
                 raise ValueError(
                     "Both ssl_cert_content and ssl_key_content must be defined when using configuring TLS"
+                )
+
+        # validate maas_url if provided
+        if maas_url := self.config["maas_url"]:
+            parsed = urlparse(str(maas_url))
+            if not parsed.scheme or not parsed.netloc:
+                raise ValueError(
+                    f"Invalid maas_url: {maas_url}. Must be a valid URL with scheme and host."
                 )
         self._reconcile_ha_proxy(event)
         maas_details = MaasHelper.get_maas_details()

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -10,6 +10,7 @@ import random
 import socket
 import string
 import subprocess
+from ipaddress import ip_address
 from typing import Any
 
 import ops
@@ -22,6 +23,7 @@ from charms.rolling_ops.v0.rollingops import RollingOpsManager, RunWithLock
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer, charm_tracing_config
 from ops.model import SecretNotFoundError
+from pydantic import IPvAnyAddress
 
 from backups import MAASBackups
 from helper import MaasHelper
@@ -336,16 +338,20 @@ class MaasRegionCharm(ops.CharmBase):
         return f"http://{self.bind_address}:{MAAS_HTTP_PORT}/MAAS"
 
     @property
-    def maas_ips(self) -> list[str]:
+    def maas_ips(self) -> list[IPvAnyAddress]:
         """Get the IP addresses of MAAS Regions in the cluster.
 
         Return:
-            list[str]: The list of connected MAAS IPs
+            list[IPvAnyAddress]: The list of connected MAAS IPs
         """
         region_ips = {self.bind_address}
-        if relation := self.peers:
-            region_ips.update(self.get_peer_data(unit, "bind-address") for unit in relation.units)
-        return [str(r).strip("'\"") for r in region_ips]
+        if self.peers:
+            region_ips.update(
+                addr
+                for unit in self.peers.units
+                if isinstance(addr := self.get_peer_data(unit, "bind-address"), str)
+            )
+        return list(map(ip_address, region_ips))
 
     def get_operational_mode(self) -> str:
         """Get expected MAAS mode.
@@ -517,8 +523,6 @@ class MaasRegionCharm(ops.CharmBase):
                 self.unit.status = ops.ActiveStatus()
             return
 
-        # TODO: Remove the `type: ignore[arg-type]` when hosts annotation is fixed.
-        # Link: https://github.com/canonical/haproxy-operator/pull/383
         haproxy_relations = [
             (haproxy_non_tls_enabled, self.haproxy_non_tls_route),
             (haproxy_temporal_route_enabled, self.haproxy_temporal_route),
@@ -528,7 +532,7 @@ class MaasRegionCharm(ops.CharmBase):
         for enabled, rel in haproxy_relations:
             if enabled:
                 if unit_valid:
-                    rel.configure_hosts(self.maas_ips)  # type: ignore[arg-type]
+                    rel.configure_hosts(self.maas_ips)
                 else:
                     rel.configure_hosts()
                 rel.update_relation_data()
@@ -706,7 +710,7 @@ class MaasRegionCharm(ops.CharmBase):
     def _on_maas_peer_changed(self, event: ops.RelationEvent) -> None:
         logger.info(event)
         self.set_peer_data(self.unit, "system-name", socket.gethostname())
-        self.set_peer_data(self.unit, "bind-address", str(self.bind_address))
+        self.set_peer_data(self.unit, "bind-address", self.bind_address)
         self._reconcile_ha_proxy_and_initialise(event)
 
     def _on_create_admin_action(self, event: ops.ActionEvent):

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -102,6 +102,7 @@ COMMON_DEFAULT_HAPROXY_ARGS = {
     "check_rise": 2,
     "check_fall": 3,
     "check_interval": 2,
+    "server_timeout": 900,
 }
 
 

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -196,6 +196,7 @@ class MaasRegionCharm(ops.CharmBase):
         self.framework.observe(self.on.get_api_key_action, self._on_get_api_key_action)
         self.framework.observe(self.on.get_api_endpoint_action, self._on_get_api_endpoint_action)
         self.framework.observe(self.on.get_maas_secret_action, self._on_get_maas_secret_action)
+        self.framework.observe(self.on.get_maas_status_action, self._on_get_maas_status_action)
 
         # Charm configuration
         self.framework.observe(self.on.config_changed, self._on_config_changed)
@@ -671,6 +672,13 @@ class MaasRegionCharm(ops.CharmBase):
             event.set_results({"maas-secret": secret})
         else:
             event.fail("MAAS is not initialized yet")
+
+    def _on_get_maas_status_action(self, event: ops.ActionEvent):
+        """Handle the get-maas-status action."""
+        if status := MaasHelper.get_maas_status():
+            event.set_results({"services": status})
+        else:
+            event.fail("MAAS is not initialized yet or failed to retrieve status")
 
     def _on_config_changed(self, event: ops.ConfigChangedEvent):
         # validate TLS certificate and key

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -33,6 +33,8 @@ MAAS_DB_NAME = "maas-db"
 MAAS_INIT_RELATION = "initialize"
 HAPROXY_NON_TLS = "ingress-tcp"
 HAPROXY_TLS = "ingress-tcp-tls"
+HAPROXY_TEMPORAL = "ingress-tcp-temporal"
+HAPROXY_INTERNAL_HTTP_API = "ingress-tcp-internal-http-api"
 
 MAAS_SNAP_CHANNEL = "3.7/stable"
 
@@ -45,6 +47,8 @@ MAAS_REGION_METRICS_PORT = 5239
 MAAS_AGENT_METRICS_PORT = 5248
 MAAS_RACK_METRICS_PORT = 5249
 MAAS_CLUSTER_METRICS_PORT = MAAS_HTTP_PORT
+MAAS_TEMPORAL_PORT = 5271
+MAAS_INTERNAL_HTTP_API_PORT = 5242
 
 MAAS_AGENT_METRICS_ENDPOINT = "/metrics/agent"
 
@@ -167,6 +171,32 @@ class MaasRegionCharm(ops.CharmBase):
         )
         self.framework.observe(self.haproxy_tls_route.on.ready, self._reconcile_ha_proxy)
         self.framework.observe(self.haproxy_tls_route.on.removed, self._reconcile_ha_proxy)
+
+        # Temporal
+        self.haproxy_temporal_route = HaproxyRouteTcpRequirer(
+            self,
+            HAPROXY_TEMPORAL,
+            port=MAAS_TEMPORAL_PORT,
+            backend_port=MAAS_TEMPORAL_PORT,
+            **COMMON_DEFAULT_HAPROXY_ARGS,
+        )
+        self.framework.observe(self.haproxy_temporal_route.on.ready, self._reconcile_ha_proxy)
+        self.framework.observe(self.haproxy_temporal_route.on.removed, self._reconcile_ha_proxy)
+
+        # Internal HTTP API
+        self.haproxy_internal_http_api_route = HaproxyRouteTcpRequirer(
+            self,
+            HAPROXY_INTERNAL_HTTP_API,
+            port=MAAS_INTERNAL_HTTP_API_PORT,
+            backend_port=MAAS_INTERNAL_HTTP_API_PORT,
+            **COMMON_DEFAULT_HAPROXY_ARGS,
+        )
+        self.framework.observe(
+            self.haproxy_internal_http_api_route.on.ready, self._reconcile_ha_proxy
+        )
+        self.framework.observe(
+            self.haproxy_internal_http_api_route.on.removed, self._reconcile_ha_proxy
+        )
 
         # COS
         endpoints: list[cos_agent._MetricsEndpointDict] = [
@@ -451,9 +481,29 @@ class MaasRegionCharm(ops.CharmBase):
         haproxy_non_tls_enabled = self.model.get_relation(HAPROXY_NON_TLS) is not None
         haproxy_tls_enabled = self.model.get_relation(HAPROXY_TLS) is not None
 
-        # if there are no relations, or the http relation is set and the https configuration is valid
-        unit_valid = (haproxy_non_tls_enabled or not haproxy_tls_enabled) and (
-            self.is_tls_config_enabled == haproxy_tls_enabled
+        haproxy_temporal_route_enabled = self.model.get_relation(HAPROXY_TEMPORAL) is not None
+        haproxy_internal_http_api_route_enabled = (
+            self.model.get_relation(HAPROXY_INTERNAL_HTTP_API) is not None
+        )
+
+        # Check if all required HAProxy relations are present (TLS is optional)
+        has_required_haproxy_relations = (
+            haproxy_non_tls_enabled
+            and haproxy_temporal_route_enabled
+            and haproxy_internal_http_api_route_enabled
+        )
+        has_any_haproxy_relation = (
+            haproxy_non_tls_enabled
+            or haproxy_tls_enabled
+            or haproxy_temporal_route_enabled
+            or haproxy_internal_http_api_route_enabled
+        )
+        # Valid scenarios:
+        # 1. No HAProxy relations at all (standalone MAAS)
+        # 2. All required HAProxy relations present without TLS (MAAS also without TLS config)
+        # 3. All required HAProxy relations present with TLS (MAAS also with TLS config)
+        unit_valid = not has_any_haproxy_relation or (
+            has_required_haproxy_relations and self.is_tls_config_enabled == haproxy_tls_enabled
         )
         logger.info(
             f"Reconciling HAProxy with haproxy_non_tls_enabled: {haproxy_non_tls_enabled}"
@@ -467,18 +517,22 @@ class MaasRegionCharm(ops.CharmBase):
                 self.unit.status = ops.ActiveStatus()
             return
 
-        if haproxy_non_tls_enabled:
-            # TODO: Remove type: ignore when hosts annotation is fixed: https://github.com/canonical/haproxy-operator/pull/383
-            self.haproxy_non_tls_route.configure_hosts(self.maas_ips)  # type: ignore[arg-type]
-            self.haproxy_non_tls_route.update_relation_data()
+        # TODO: Remove the `type: ignore[arg-type]` when hosts annotation is fixed.
+        # Link: https://github.com/canonical/haproxy-operator/pull/383
+        haproxy_relations = [
+            (haproxy_non_tls_enabled, self.haproxy_non_tls_route),
+            (haproxy_temporal_route_enabled, self.haproxy_temporal_route),
+            (haproxy_internal_http_api_route_enabled, self.haproxy_internal_http_api_route),
+            (haproxy_tls_enabled, self.haproxy_tls_route),
+        ]
+        for enabled, rel in haproxy_relations:
+            if enabled:
+                if unit_valid:
+                    rel.configure_hosts(self.maas_ips)  # type: ignore[arg-type]
+                else:
+                    rel.configure_hosts()
+                rel.update_relation_data()
 
-        if haproxy_tls_enabled:
-            if haproxy_non_tls_enabled and self.is_tls_config_enabled:
-                # TODO: Remove type: ignore when hosts annotation is fixed: https://github.com/canonical/haproxy-operator/pull/383
-                self.haproxy_tls_route.configure_hosts(self.maas_ips)  # type: ignore[arg-type]
-            else:
-                self.haproxy_tls_route.configure_hosts()
-            self.haproxy_tls_route.update_relation_data()
         if unit_valid:
             self.unit.status = ops.ActiveStatus()
 
@@ -561,33 +615,59 @@ class MaasRegionCharm(ops.CharmBase):
             e.add_status(ops.WaitingStatus("Waiting for database DSN"))
         elif not self.maas_api_url:
             e.add_status(ops.WaitingStatus("Waiting for MAAS initialization"))
-        elif (
-            self.is_tls_config_enabled
-            and self.model.get_relation(HAPROXY_NON_TLS) is not None
-            and self.model.get_relation(HAPROXY_TLS) is None
-        ):
-            e.add_status(
-                ops.BlockedStatus(
-                    "Invalid HAProxy configuration: Missing `ingress-tcp-tls` relation."
-                )
-            )
-        elif (
-            self.model.get_relation(HAPROXY_NON_TLS) is None
-            and self.model.get_relation(HAPROXY_TLS) is not None
-        ):
-            e.add_status(
-                ops.BlockedStatus("Invalid HAProxy configuration: Missing `ingress-tcp` relation.")
-            )
-        elif not self.is_tls_config_enabled and self.model.get_relation(HAPROXY_TLS) is not None:
-            e.add_status(
-                ops.BlockedStatus(
-                    "Invalid HAProxy configuration: "
-                    "Cannot have `ingress-tcp-tls` relation when MAAS TLS is not enabled; "
-                    "Set the `ssl_cert_content` and `ssl_key_content` configuration options."
-                )
-            )
         else:
-            logger.debug("no status change based on prerequisites")
+            # Check HAProxy configuration validity
+            haproxy_non_tls = self.model.get_relation(HAPROXY_NON_TLS) is not None
+            haproxy_tls = self.model.get_relation(HAPROXY_TLS) is not None
+            haproxy_temporal = self.model.get_relation(HAPROXY_TEMPORAL) is not None
+            haproxy_internal_http_api = (
+                self.model.get_relation(HAPROXY_INTERNAL_HTTP_API) is not None
+            )
+
+            has_required_relations = (
+                haproxy_non_tls and haproxy_temporal and haproxy_internal_http_api
+            )
+            has_any_haproxy_relation = (
+                haproxy_non_tls or haproxy_tls or haproxy_temporal or haproxy_internal_http_api
+            )
+
+            # Invalid: HAProxy TLS relation present but MAAS TLS not enabled
+            if not self.is_tls_config_enabled and haproxy_tls:
+                e.add_status(
+                    ops.BlockedStatus(
+                        "Invalid HAProxy configuration: "
+                        f"Cannot have `{HAPROXY_TLS}` relation when MAAS TLS is not enabled; "
+                        "Set the `ssl_cert_content` and `ssl_key_content` configuration options."
+                    )
+                )
+            # Invalid: MAAS TLS enabled with required relations but missing HAProxy TLS
+            elif self.is_tls_config_enabled and has_required_relations and not haproxy_tls:
+                e.add_status(
+                    ops.BlockedStatus(
+                        f"Invalid HAProxy configuration: Missing `{HAPROXY_TLS}` relation "
+                        "when MAAS TLS is enabled."
+                    )
+                )
+            # Invalid: HAProxy TLS relation present without all required base relations
+            elif haproxy_tls and not has_required_relations:
+                e.add_status(
+                    ops.BlockedStatus(
+                        "Invalid HAProxy configuration: "
+                        f"`{HAPROXY_TLS}` relation requires all base relations: "
+                        f"`{HAPROXY_NON_TLS}`, `{HAPROXY_TEMPORAL}`, and `{HAPROXY_INTERNAL_HTTP_API}`."
+                    )
+                )
+            # Invalid: Partial HAProxy relations (not all required together)
+            elif has_any_haproxy_relation and not has_required_relations:
+                e.add_status(
+                    ops.BlockedStatus(
+                        "Invalid HAProxy configuration: "
+                        f"All of `{HAPROXY_NON_TLS}`, `{HAPROXY_TEMPORAL}`, and `{HAPROXY_INTERNAL_HTTP_API}` "
+                        "relations must be present together if any are provided."
+                    )
+                )
+            else:
+                logger.debug("no status change based on prerequisites")
 
     def _on_maasdb_created(self, event: db.DatabaseCreatedEvent) -> None:
         """Database is ready.

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -272,7 +272,20 @@ class MaasHelper:
                     ]
                 )
 
-            subprocess.check_call(login_cmd, stdout=subprocess.DEVNULL)
+            try:
+                subprocess.run(
+                    login_cmd,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                    check=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as e:
+                # Log the last line of stderr from the failed command
+                if e.stderr:
+                    last_line = e.stderr.strip().splitlines()[-1]
+                    logger.warning(f"MAAS login failed: {last_line}")
+                raise
 
     @staticmethod
     def _logout(admin_username: str) -> None:
@@ -352,13 +365,13 @@ class MaasHelper:
         return {region["system_id"] for region in region_data}
 
     @staticmethod
-    def is_maas_initialised() -> bool:
-        """Check whether MAAS is initialised.
+    def is_maas_initialized() -> bool:
+        """Check whether MAAS is initialized.
 
         Returns:
-            bool: True if MAAS is initialised, False if not.
+            bool: True if MAAS is initialized, False if not.
         """
-        # this file is always created when MAAS is initialised.
+        # this file is always created when MAAS is initialized.
         # Technically this is a side effect of, rather than a MAAS expected
         # way of testing status, so may need to be replaced in future.
         return NGINX_CFG_FILEPATH.exists()

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -475,3 +475,80 @@ class MaasHelper:
                 return file.readline().strip()
         except OSError:
             return None
+
+    @staticmethod
+    def get_maas_status() -> dict[str, dict[str, str]]:
+        """Get MAAS status information.
+
+        Example output of `maas status` command:
+
+        ```
+        Service          Startup   Current   Since
+        agent            disabled  active    today at 07:48 UTC
+        apiserver        enabled   active    today at 07:48 UTC
+        bind9            disabled  active    today at 07:48 UTC
+        dhcpd            disabled  active    today at 07:48 UTC
+        dhcpd6           disabled  inactive  -
+        http             disabled  active    today at 07:48 UTC
+        ntp              disabled  active    today at 07:48 UTC
+        proxy            disabled  active    today at 07:48 UTC
+        rackd            enabled   active    today at 07:48 UTC
+        regiond          enabled   active    today at 07:48 UTC
+        syslog           disabled  active    today at 07:48 UTC
+        temporal         disabled  active    today at 07:48 UTC
+        temporal-worker  disabled  active    today at 07:48 UTC
+        ```
+
+        Returns:
+            dict[str, dict[str, str]]: Dictionary mapping service names to their status information (startup, current, since), or empty dict if MAAS is not initialized or output format is unexpected
+        """
+        # Valid values for validation
+        valid_headers = {"service", "startup", "current", "since"}
+        valid_startup = {"enabled", "disabled"}
+        valid_status = {"active", "backoff", "error", "inactive"}
+
+        cmd = [
+            "/snap/bin/maas",
+            "status",
+        ]
+        try:
+            output = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode()
+        except subprocess.CalledProcessError as e:
+            logger.warning(f"Failed to get MAAS status: {e}")
+            return {}
+
+        try:
+            header, *lines = output.strip().splitlines()
+        except ValueError as e:
+            logger.warning(f"Failed to parse MAAS status output: {e}")
+            return {}
+
+        headers = header.lower().split()
+        if set(headers) != valid_headers:
+            logger.warning(f"Unexpected MAAS status headers: {headers}, expected: {valid_headers}")
+            return {}
+
+        services = {}
+        for line in lines:
+            parts = line.split(maxsplit=len(headers) - 1)
+            if len(parts) != len(headers):
+                logger.debug(f"Skipping service with unexpected line format: {line}")
+                continue
+
+            entry = dict(zip(headers, parts))
+
+            # Validate startup and current fields have expected values
+            if entry.get("startup") not in valid_startup:
+                logger.debug(f"Skipping service with invalid startup value: {entry}")
+                continue
+            if entry.get("current") not in valid_status:
+                logger.debug(f"Skipping service with invalid status value: {entry}")
+                continue
+
+            service_name = entry.pop("service")
+            services[service_name] = entry
+
+        if not services and lines:
+            logger.warning("All services were filtered out due to validation failures")
+
+        return services

--- a/maas-region/tests/integration/conftest.py
+++ b/maas-region/tests/integration/conftest.py
@@ -5,3 +5,4 @@ import yaml
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 POSTGRESQL_CHANNEL = "16/stable"
+HAPROXY_CHANNEL = "2.8/edge"

--- a/maas-region/tests/integration/test_charm.py
+++ b/maas-region/tests/integration/test_charm.py
@@ -190,6 +190,8 @@ async def test_haproxy_integration(ops_test: OpsTest, tmp_path):
 
     key, cacert, cert = generate_cert(ip_address=address, tmp_path=tmp_path)
     await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp", "haproxy")
+    await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp-temporal", "haproxy")
+    await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp-internal-http-api", "haproxy")
     await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp-tls", "haproxy")
     await ops_test.model.applications[APP_NAME].set_config({"ssl_cert_content": cert})
     await ops_test.model.applications[APP_NAME].set_config({"ssl_key_content": key})
@@ -215,8 +217,14 @@ async def test_haproxy_integration(ops_test: OpsTest, tmp_path):
             if return_code == 0:
                 haproxy_data = read_haproxy_blocks(stdout)
                 http_frontend = haproxy_data["frontend haproxy_route_tcp_80"]
+                temporal_frontend = haproxy_data["frontend haproxy_route_tcp_5271"]
+                internal_http_api_frontend = haproxy_data["frontend haproxy_route_tcp_5242"]
                 https_frontend = haproxy_data["frontend haproxy_route_tcp_443"]
                 http_backend = haproxy_data["backend haproxy_route_tcp_80_default_backend"]
+                temporal_backend = haproxy_data["backend haproxy_route_tcp_5271_default_backend"]
+                internal_http_api_backend = haproxy_data[
+                    "backend haproxy_route_tcp_5242_default_backend"
+                ]
                 https_backend = haproxy_data["backend haproxy_route_tcp_443_default_backend"]
                 break
         except KeyError:
@@ -230,6 +238,14 @@ async def test_haproxy_integration(ops_test: OpsTest, tmp_path):
     assert "mode tcp" in http_frontend
     assert "bind [::]:80" in http_frontend
     assert re.search(r"server maas-region-0 (\d+\.){3}\d+:5240", http_backend)
+
+    assert "mode tcp" in temporal_frontend
+    assert "bind [::]:5271" in temporal_frontend
+    assert re.search(r"server maas-region-0 (\d+\.){3}\d+:5271", temporal_backend)
+
+    assert "mode tcp" in internal_http_api_frontend
+    assert "bind [::]:5242" in internal_http_api_frontend
+    assert re.search(r"server maas-region-0 (\d+\.){3}\d+:5242", internal_http_api_backend)
 
     assert "mode tcp" in https_frontend
     assert "bind [::]:443" in https_frontend

--- a/maas-region/tests/integration/test_charm.py
+++ b/maas-region/tests/integration/test_charm.py
@@ -68,7 +68,7 @@ async def test_database_integration(ops_test: OpsTest):
     )
 
 
-def generate_cert(ip_address: str, tmp_path: Path):
+def generate_cert(ip_addresses: list[str], tmp_path: Path):
     ca_key = tmp_path / "ca.key"
     ca_crt = tmp_path / "ca.crt"
     maas_key = tmp_path / "maas.key"
@@ -76,6 +76,7 @@ def generate_cert(ip_address: str, tmp_path: Path):
     maas_crt = tmp_path / "maas.crt"
     conf = tmp_path / "maas.conf"
 
+    alt_names = "\n".join(f"IP.{i + 1} = {ip}" for i, ip in enumerate(ip_addresses))
     conf.write_text(f"""\
 [ req ]
 default_bits       = 4096
@@ -85,13 +86,13 @@ distinguished_name = dn
 req_extensions     = req_ext
 
 [ dn ]
-CN = {ip_address}
+CN = {ip_addresses[0]}
 
 [ req_ext ]
 subjectAltName = @alt_names
 
 [ alt_names ]
-IP.1 = {ip_address}
+{alt_names}
 """)
 
     for key in [ca_key, maas_key]:
@@ -187,8 +188,9 @@ async def test_haproxy_integration(ops_test: OpsTest, tmp_path):
     )
 
     address = await ops_test.model.applications[APP_NAME].units[0].get_public_address()
+    haproxy_address = await ops_test.model.applications["haproxy"].units[0].get_public_address()
 
-    key, cacert, cert = generate_cert(ip_address=address, tmp_path=tmp_path)
+    key, cacert, cert = generate_cert(ip_addresses=[address, haproxy_address], tmp_path=tmp_path)
     await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp", "haproxy")
     await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp-temporal", "haproxy")
     await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp-internal-http-api", "haproxy")

--- a/maas-region/tests/integration/test_charm.py
+++ b/maas-region/tests/integration/test_charm.py
@@ -53,11 +53,7 @@ async def test_database_integration(ops_test: OpsTest):
             application_name="postgresql",
             channel=POSTGRESQL_CHANNEL,
             series="noble",
-            trust=True,
-            # workaround for https://bugs.launchpad.net/maas/+bug/2097079
-            config={"plugin_audit_enable": False},
-            # workaround for https://bugs.launchpad.net/maas/+bug/2097079, https://github.com/canonical/postgresql-operator/issues/1001
-            revision=758,
+            config={"plugin_btree_gin_enable": True},
         ),
         ops_test.model.wait_for_idle(
             apps=["postgresql"], status="active", raise_on_blocked=True, timeout=1000
@@ -185,7 +181,6 @@ async def test_haproxy_integration(ops_test: OpsTest, tmp_path):
         application_name="haproxy",
         channel=HAPROXY_CHANNEL,
         series="noble",
-        trust=True,
     )
     await ops_test.model.wait_for_idle(
         apps=["haproxy", APP_NAME], status="active", raise_on_blocked=True, timeout=3600

--- a/maas-region/tests/integration/test_charm_ha.py
+++ b/maas-region/tests/integration/test_charm_ha.py
@@ -68,9 +68,7 @@ async def test_multi_node_database_integration(ops_test: OpsTest):
             application_name="postgresql",
             channel=POSTGRESQL_CHANNEL,
             series="noble",
-            trust=True,
-            # workaround for https://bugs.launchpad.net/maas/+bug/2097079
-            config={"plugin_audit_enable": False},
+            config={"plugin_btree_gin_enable": True},
         ),
         ops_test.model.wait_for_idle(
             apps=["postgresql"], status="active", raise_on_blocked=True, timeout=1000

--- a/maas-region/tests/unit/test_backup.py
+++ b/maas-region/tests/unit/test_backup.py
@@ -2117,7 +2117,10 @@ backup-id            | action      | status   | maas     | size       | controll
 
     @patch("pathlib.Path.write_text")
     @patch("backups.MAASBackups._download_file_from_s3")
-    def test_run_restore__controller_id_update_ok(self, download_file, _write_text):
+    @patch("charm.MaasRegionCharm.bind_address", new_callable=PropertyMock)
+    def test_run_restore__controller_id_update_ok(self, mock_bind, download_file, _write_text):
+        mock_bind.return_value = "10.0.0.1"
+
         backup_id = "2025-08-23T06:26:00Z"
         controller_id = "abc123"
         s3_parameters = {
@@ -2230,7 +2233,9 @@ backup-id            | action      | status   | maas     | size       | controll
         event.fail.assert_called_with("Restore failed: Could not fetch MAAS regions list")
 
     @patch("backups.MAASBackups._download_file_from_s3")
-    def test_run_restore__incorrect_region_count(self, download_file):
+    @patch("charm.MaasRegionCharm.bind_address", new_callable=PropertyMock)
+    def test_run_restore__incorrect_region_count(self, mock_bind, download_file):
+        mock_bind.return_value = "10.0.0.1"
         backup_id = "2025-08-23T06:26:00Z"
         controller_id = "abc123"
         s3_parameters = {
@@ -2275,7 +2280,10 @@ backup-id            | action      | status   | maas     | size       | controll
         )
 
     @patch("backups.MAASBackups._download_file_from_s3")
-    def test_run_restore__invalid_controller_id(self, download_file):
+    @patch("charm.MaasRegionCharm.bind_address", new_callable=PropertyMock)
+    def test_run_restore__invalid_controller_id(self, mock_bind, download_file):
+        mock_bind.return_value = "10.0.0.1"
+
         backup_id = "2025-08-23T06:26:00Z"
         controller_id = "abc123"
         s3_parameters = {

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -526,6 +526,36 @@ class TestCharmActions(unittest.TestCase):
         err = e.exception
         self.assertEqual(err.message, "MAAS is not initialized yet")
 
+    @patch("charm.MaasHelper", autospec=True)
+    def test_get_maas_status_action(self, mock_helper):
+        self.harness.set_leader(True)
+        self.harness.begin()
+        mock_status = {
+            "agent": {
+                "startup": "disabled",
+                "current": "active",
+                "since": "today at 07:48 UTC",
+            },
+            "regiond": {
+                "startup": "enabled",
+                "current": "active",
+                "since": "today at 07:48 UTC",
+            },
+        }
+        mock_helper.get_maas_status.return_value = mock_status
+        output = self.harness.run_action("get-maas-status")
+        self.assertEqual(output.results["services"], mock_status)
+
+    @patch("charm.MaasHelper", autospec=True)
+    def test_get_maas_status_action_fail(self, mock_helper):
+        self.harness.set_leader(True)
+        self.harness.begin()
+        mock_helper.get_maas_status.return_value = {}
+        with self.assertRaises(ops.testing.ActionFailed) as e:
+            self.harness.run_action("get-maas-status")
+        err = e.exception
+        self.assertEqual(err.message, "MAAS is not initialized yet or failed to retrieve status")
+
     @patch(
         "charm.MaasRegionCharm.bind_address",
         new_callable=PropertyMock(return_value="10.0.0.10"),

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -214,6 +214,17 @@ class TestClusterUpdates(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.harness.update_config({"ssl_cert_content": "test_cert"})
 
+    def test_invalid_maas_url_config(self):
+        """Test that invalid maas_url raises ValueError on config change."""
+        invalid_urls = ["not-a-url", "/just/a/path", "http://"]
+        for invalid_url in invalid_urls:
+            with self.subTest(url=invalid_url):
+                harness = self._make_harness()
+                harness.begin()
+                with self.assertRaises(ValueError) as cm:
+                    harness.update_config({"maas_url": invalid_url})
+                self.assertIn("Invalid maas_url", str(cm.exception))
+
     @patch("charm.MaasHelper", autospec=True)
     def test_on_maas_cluster_changed_prometheus_enabled(self, mock_helper):
         mock_helper.get_maas_mode.return_value = "region"
@@ -710,3 +721,126 @@ class TestCharmActions(unittest.TestCase):
         self.harness.begin()
         with self.assertRaises(subprocess.CalledProcessError):
             self.harness.charm.get_region_system_ids()
+
+
+class TestMAASURLs(unittest.TestCase):
+    """Test maas_cli_url and maas_api_url properties."""
+
+    def setUp(self):
+        self.harness = ops.testing.Harness(MaasRegionCharm)
+        self.harness.add_network("10.0.0.10")
+        self.addCleanup(self.harness.cleanup)
+
+    def test_maas_cli_url_with_config(self):
+        """Test maas_cli_url returns configured URL when maas_url is set."""
+        self.harness.update_config({"maas_url": "https://custom.maas.example.com/MAAS"})
+        self.harness.begin()
+        self.assertEqual(self.harness.charm.maas_cli_url, "https://custom.maas.example.com/MAAS")
+
+    def test_maas_cli_url_with_haproxy_non_tls(self):
+        """Test maas_cli_url uses HAProxy non-TLS endpoint when TLS is disabled."""
+        self.harness.begin()
+        rel_id = self.harness.add_relation(HAPROXY_NON_TLS, "haproxy")
+        self.harness.update_relation_data(rel_id, "haproxy", {"endpoints": '["10.226.71.86:80"]'})
+        self.assertEqual(self.harness.charm.maas_cli_url, "http://10.226.71.86:80/MAAS")
+
+    def test_maas_cli_url_with_haproxy_tls(self):
+        """Test maas_cli_url uses HAProxy TLS endpoint when TLS is enabled."""
+        self.harness.update_config(
+            {
+                "ssl_cert_content": "cert-content",
+                "ssl_key_content": "key-content",
+            }
+        )
+        self.harness.begin()
+        rel_id = self.harness.add_relation(HAPROXY_TLS, "haproxy")
+        self.harness.update_relation_data(rel_id, "haproxy", {"endpoints": '["10.226.71.86:443"]'})
+        self.assertEqual(self.harness.charm.maas_cli_url, "https://10.226.71.86:443/MAAS")
+
+    def test_maas_cli_url_fallback_to_bind_address_non_tls(self):
+        """Test maas_cli_url falls back to bind address when no HAProxy (non-TLS)."""
+        self.harness.begin()
+        self.assertEqual(
+            self.harness.charm.maas_cli_url, f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS"
+        )
+
+    def test_maas_cli_url_fallback_to_bind_address_tls(self):
+        """Test maas_cli_url falls back to bind address when no HAProxy (TLS)."""
+        self.harness.update_config(
+            {
+                "ssl_cert_content": "cert-content",
+                "ssl_key_content": "key-content",
+            }
+        )
+        self.harness.begin()
+        self.assertEqual(
+            self.harness.charm.maas_cli_url, f"https://10.0.0.10:{MAAS_HTTPS_PORT}/MAAS"
+        )
+
+    def test_maas_cli_url_handles_malformed_endpoints(self):
+        """Test maas_cli_url handles malformed HAProxy endpoints and falls back to bind address."""
+        cases = [
+            ("invalid_json", "invalid-json"),
+            ("empty_list", "[]"),
+            ("non_list_json", '{"key": "value"}'),
+        ]
+        for name, endpoints_value in cases:
+            with self.subTest(case=name):
+                self.harness.begin()
+                rel_id = self.harness.add_relation(HAPROXY_NON_TLS, "haproxy")
+                self.harness.update_relation_data(
+                    rel_id, "haproxy", {"endpoints": endpoints_value}
+                )
+                self.assertEqual(
+                    self.harness.charm.maas_cli_url, f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS"
+                )
+                self.harness.cleanup()
+                self.harness = ops.testing.Harness(MaasRegionCharm)
+                self.harness.add_network("10.0.0.10")
+
+    def test_maas_api_url_with_config(self):
+        """Test maas_api_url converts https to http from configured URL."""
+        self.harness.update_config({"maas_url": "https://custom.maas.example.com/MAAS"})
+        self.harness.begin()
+        self.assertEqual(self.harness.charm.maas_api_url, "http://custom.maas.example.com/MAAS")
+
+    def test_maas_api_url_with_http_config(self):
+        """Test maas_api_url keeps http scheme from configured URL."""
+        self.harness.update_config({"maas_url": "http://custom.maas.example.com/MAAS"})
+        self.harness.begin()
+        self.assertEqual(self.harness.charm.maas_api_url, "http://custom.maas.example.com/MAAS")
+
+    def test_maas_api_url_with_haproxy(self):
+        """Test maas_api_url uses HAProxy non-TLS endpoint."""
+        self.harness.begin()
+        rel_id = self.harness.add_relation(HAPROXY_NON_TLS, "haproxy")
+        self.harness.update_relation_data(rel_id, "haproxy", {"endpoints": '["10.226.71.86:80"]'})
+        self.assertEqual(self.harness.charm.maas_api_url, "http://10.226.71.86:80/MAAS")
+
+    def test_maas_api_url_fallback_to_bind_address(self):
+        """Test maas_api_url falls back to bind address when no HAProxy."""
+        self.harness.begin()
+        self.assertEqual(
+            self.harness.charm.maas_api_url, f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS"
+        )
+
+    def test_maas_api_url_handles_malformed_endpoints(self):
+        """Test maas_api_url handles malformed HAProxy endpoints and falls back to bind address."""
+        cases = [
+            ("invalid_json", "invalid-json"),
+            ("empty_list", "[]"),
+            ("non_list_json", '{"key": "value"}'),
+        ]
+        for name, endpoints_value in cases:
+            with self.subTest(case=name):
+                self.harness.begin()
+                rel_id = self.harness.add_relation(HAPROXY_NON_TLS, "haproxy")
+                self.harness.update_relation_data(
+                    rel_id, "haproxy", {"endpoints": endpoints_value}
+                )
+                self.assertEqual(
+                    self.harness.charm.maas_api_url, f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS"
+                )
+                self.harness.cleanup()
+                self.harness = ops.testing.Harness(MaasRegionCharm)
+                self.harness.add_network("10.0.0.10")

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -17,8 +17,11 @@ from charm import (
     HAPROXY_NON_TLS,
     MAAS_DB_NAME,
     MAAS_HTTP_PORT,
+    MAAS_HTTPS_PORT,
     MAAS_PEER_NAME,
+    MAAS_PROXY_PORT,
     MAAS_SNAP_CHANNEL,
+    MAAS_TLS_PROXY_PORT,
     MaasRegionCharm,
 )
 
@@ -209,6 +212,17 @@ class TestClusterUpdates(unittest.TestCase):
         mock_helper.get_maas_mode.return_value = "region"
         mock_helper.create_admin_user.return_value = None
         self.harness.set_leader(True)
+        db_rel = self.harness.add_relation(MAAS_DB_NAME, "postgresql")
+        self.harness.update_relation_data(
+            db_rel,
+            "postgresql",
+            {
+                "endpoints": "30.0.0.1:5432",
+                "read-only-endpoints": "30.0.0.2:5432",
+                "username": "test_maas_db",
+                "password": "my_secret",
+            },
+        )
         self.harness.update_config({"enable_rack_mode": False})
         self.harness.begin()
         self.harness.update_config({"enable_rack_mode": True})
@@ -248,10 +262,27 @@ class TestClusterUpdates(unittest.TestCase):
         mock_helper.setup_region.return_value = None
         mock_helper.create_admin_user.return_value = None
         self.harness.set_leader(True)
+        db_rel = self.harness.add_relation(MAAS_DB_NAME, "postgresql")
+        self.harness.update_relation_data(
+            db_rel,
+            "postgresql",
+            {
+                "endpoints": "30.0.0.1:5432",
+                "read-only-endpoints": "30.0.0.2:5432",
+                "username": "test_maas_db",
+                "password": "my_secret",
+            },
+        )
         self.harness.update_config({"enable_rack_mode": True})
         self.harness.begin_with_initial_hooks()
         mock_helper.setup_region.assert_has_calls(
-            [call(f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS", "", "region+rack")]
+            [
+                call(
+                    f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS",
+                    "postgres://test_maas_db:my_secret@30.0.0.1:5432/maas_region_db",
+                    "region+rack",
+                )
+            ]
         )
 
     @patch("charm.MaasHelper", autospec=True)
@@ -261,13 +292,32 @@ class TestClusterUpdates(unittest.TestCase):
         mock_helper.setup_region.return_value = None
         mock_helper.create_admin_user.return_value = None
         self.harness.set_leader(True)
+        db_rel = self.harness.add_relation(MAAS_DB_NAME, "postgresql")
+        self.harness.update_relation_data(
+            db_rel,
+            "postgresql",
+            {
+                "endpoints": "30.0.0.1:5432",
+                "read-only-endpoints": "30.0.0.2:5432",
+                "username": "test_maas_db",
+                "password": "my_secret",
+            },
+        )
         self.harness.update_config({"enable_rack_mode": False})
         self.harness.begin_with_initial_hooks()
         self.harness.update_config({"enable_rack_mode": True})
         mock_helper.setup_region.assert_has_calls(
             [
-                call(f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS", "", "region"),
-                call(f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS", "", "region+rack"),
+                call(
+                    f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS",
+                    "postgres://test_maas_db:my_secret@30.0.0.1:5432/maas_region_db",
+                    "region",
+                ),
+                call(
+                    f"http://10.0.0.10:{MAAS_HTTP_PORT}/MAAS",
+                    "postgres://test_maas_db:my_secret@30.0.0.1:5432/maas_region_db",
+                    "region+rack",
+                ),
             ]
         )
 
@@ -280,15 +330,13 @@ class TestClusterUpdates(unittest.TestCase):
 
         with patch.object(
             self.harness.charm.haproxy_non_tls_route,
-            "provide_haproxy_route_tcp_requirements",
-        ) as provide:
+            "configure_hosts",
+        ) as configure_hosts:
             self.harness.charm._reconcile_ha_proxy(None)
-            provide.assert_called_once()
+            configure_hosts.assert_called_once()
 
-            kwargs = provide.call_args.kwargs
-
-            self.assertEqual(kwargs["port"], 80)
-            self.assertEqual(kwargs["hosts"], ["10.0.0.10"])
+            args = configure_hosts.call_args.args
+            self.assertEqual(args, (["10.0.0.10"],))
 
             self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
 
@@ -312,15 +360,14 @@ class TestClusterUpdates(unittest.TestCase):
 
         with patch.object(
             self.harness.charm.haproxy_tls_route,
-            "provide_haproxy_route_tcp_requirements",
-        ) as provide:
+            "configure_hosts",
+        ) as configure_hosts:
             self.harness.charm._reconcile_ha_proxy(None)
-            provide.assert_called_once()
+            configure_hosts.assert_called_once()
 
-            kwargs = provide.call_args.kwargs
+            args = configure_hosts.call_args.args
 
-            self.assertEqual(kwargs["port"], 443)
-            self.assertEqual(kwargs["hosts"], ["10.0.0.10"])
+            self.assertEqual(args, (["10.0.0.10"],))
 
             self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
 
@@ -362,12 +409,14 @@ class TestClusterUpdates(unittest.TestCase):
 
                 if http_enabled:
                     http_data = harness.get_relation_data(http_rel_id, harness.charm.app.name)
-                    self.assertEqual(http_data["port"], "80")
+                    self.assertEqual(http_data["port"], str(MAAS_PROXY_PORT))
+                    self.assertEqual(http_data["backend_port"], str(MAAS_HTTP_PORT))
                     self.assertEqual(http_data["hosts"], dumps(["10.0.0.10"]))
 
                 if https_enabled:
                     https_data = harness.get_relation_data(https_rel_id, harness.charm.app.name)
-                    self.assertEqual(https_data["port"], "443")
+                    self.assertEqual(https_data["port"], str(MAAS_TLS_PROXY_PORT))
+                    self.assertEqual(https_data["backend_port"], str(MAAS_HTTPS_PORT))
 
                     # hosts are empty if the topology is invalid
                     if http_enabled and tls_enabled:

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -14,13 +14,18 @@ from charms.maas_site_manager_k8s.v0 import enroll
 from charms.operator_libs_linux.v2.snap import SnapError
 
 from charm import (
+    HAPROXY_INTERNAL_HTTP_API,
     HAPROXY_NON_TLS,
+    HAPROXY_TEMPORAL,
+    HAPROXY_TLS,
     MAAS_DB_NAME,
     MAAS_HTTP_PORT,
     MAAS_HTTPS_PORT,
+    MAAS_INTERNAL_HTTP_API_PORT,
     MAAS_PEER_NAME,
     MAAS_PROXY_PORT,
     MAAS_SNAP_CHANNEL,
+    MAAS_TEMPORAL_PORT,
     MAAS_TLS_PROXY_PORT,
     MaasRegionCharm,
 )
@@ -181,6 +186,7 @@ class TestClusterUpdates(unittest.TestCase):
 
     def setUp(self):
         self.harness = self._make_harness()
+        self.harness.add_relation("initialize", "maas-region")
 
     def test_peer_relation_data(self):
         self.harness.set_leader(True)
@@ -324,8 +330,12 @@ class TestClusterUpdates(unittest.TestCase):
     def test_haproxy_relation__leader_sets_http_data(self):
         self.harness.set_leader(True)
 
-        rel_id = self.harness.add_relation("ingress-tcp", "haproxy")
-        self.harness.add_relation_unit(rel_id, "haproxy/0")
+        http_rel_id = self.harness.add_relation(HAPROXY_NON_TLS, "haproxy")
+        self.harness.add_relation_unit(http_rel_id, "haproxy/0")
+        temporal_rel_id = self.harness.add_relation(HAPROXY_TEMPORAL, "haproxy")
+        self.harness.add_relation_unit(temporal_rel_id, "haproxy/0")
+        internal_api_rel_id = self.harness.add_relation(HAPROXY_INTERNAL_HTTP_API, "haproxy")
+        self.harness.add_relation_unit(internal_api_rel_id, "haproxy/0")
         self.harness.begin()
 
         with patch.object(
@@ -350,10 +360,16 @@ class TestClusterUpdates(unittest.TestCase):
             }
         )
 
-        http_rel_id = self.harness.add_relation("ingress-tcp", "haproxy")
+        http_rel_id = self.harness.add_relation(HAPROXY_NON_TLS, "haproxy")
         self.harness.add_relation_unit(http_rel_id, "haproxy/0")
 
-        https_rel_id = self.harness.add_relation("ingress-tcp-tls", "haproxy")
+        temporal_rel_id = self.harness.add_relation(HAPROXY_TEMPORAL, "haproxy")
+        self.harness.add_relation_unit(temporal_rel_id, "haproxy/0")
+
+        internal_api_rel_id = self.harness.add_relation(HAPROXY_INTERNAL_HTTP_API, "haproxy")
+        self.harness.add_relation_unit(internal_api_rel_id, "haproxy/0")
+
+        https_rel_id = self.harness.add_relation(HAPROXY_TLS, "haproxy")
         self.harness.add_relation_unit(https_rel_id, "haproxy/0")
 
         self.harness.begin()
@@ -373,14 +389,15 @@ class TestClusterUpdates(unittest.TestCase):
 
     def test_haproxy_relation__leader_has_correct_data(self):
         cases = [
-            (False, False, False, True),
-            (True, False, False, True),
-            (False, True, False, False),
-            (True, True, False, False),
-            (False, False, True, False),
-            (True, False, True, False),
-            (False, True, True, False),
-            (True, True, True, True),
+            # (http_enabled, https_enabled, tls_enabled, valid)
+            (False, False, False, True),  # No HAProxy, MAAS no TLS - Valid
+            (False, True, False, False),  # Only HAProxy TLS, MAAS no TLS - Invalid
+            (False, False, True, True),  # No HAProxy, MAAS TLS - Valid
+            (False, True, True, False),  # Only HAProxy TLS, MAAS TLS - Invalid
+            (True, False, False, True),  # All required, no HAProxy TLS, MAAS no TLS - Valid
+            (True, True, False, False),  # All required, HAProxy TLS, MAAS no TLS - Invalid
+            (True, False, True, False),  # All required, no HAProxy TLS, MAAS TLS - Invalid
+            (True, True, True, True),  # All required, HAProxy TLS, MAAS TLS - Valid
         ]
         for http_enabled, https_enabled, tls_enabled, valid in cases:
             with self.subTest(http=http_enabled, https=https_enabled, tls=tls_enabled):
@@ -388,11 +405,17 @@ class TestClusterUpdates(unittest.TestCase):
                 harness.set_leader(True)
 
                 if http_enabled:
-                    http_rel_id = harness.add_relation("ingress-tcp", "haproxy")
+                    http_rel_id = harness.add_relation(HAPROXY_NON_TLS, "haproxy")
                     harness.add_relation_unit(http_rel_id, "haproxy/0")
+                    temporal_rel_id = harness.add_relation(HAPROXY_TEMPORAL, "haproxy")
+                    harness.add_relation_unit(temporal_rel_id, "haproxy/0")
+                    internal_api_rel_id = harness.add_relation(
+                        HAPROXY_INTERNAL_HTTP_API, "haproxy"
+                    )
+                    harness.add_relation_unit(internal_api_rel_id, "haproxy/0")
 
                 if https_enabled:
-                    https_rel_id = harness.add_relation("ingress-tcp-tls", "haproxy")
+                    https_rel_id = harness.add_relation(HAPROXY_TLS, "haproxy")
                     harness.add_relation_unit(https_rel_id, "haproxy/0")
 
                 if tls_enabled:
@@ -411,15 +434,34 @@ class TestClusterUpdates(unittest.TestCase):
                     http_data = harness.get_relation_data(http_rel_id, harness.charm.app.name)
                     self.assertEqual(http_data["port"], str(MAAS_PROXY_PORT))
                     self.assertEqual(http_data["backend_port"], str(MAAS_HTTP_PORT))
-                    self.assertEqual(http_data["hosts"], dumps(["10.0.0.10"]))
+                    temporal_data = harness.get_relation_data(
+                        temporal_rel_id, harness.charm.app.name
+                    )
+                    self.assertEqual(temporal_data["port"], str(MAAS_TEMPORAL_PORT))
+                    self.assertEqual(temporal_data["backend_port"], str(MAAS_TEMPORAL_PORT))
+                    internal_api_data = harness.get_relation_data(
+                        internal_api_rel_id, harness.charm.app.name
+                    )
+                    self.assertEqual(internal_api_data["port"], str(MAAS_INTERNAL_HTTP_API_PORT))
+                    self.assertEqual(
+                        internal_api_data["backend_port"], str(MAAS_INTERNAL_HTTP_API_PORT)
+                    )
+                    # hosts are only set if topology is valid
+                    if valid:
+                        self.assertEqual(http_data["hosts"], dumps(["10.0.0.10"]))
+                        self.assertEqual(temporal_data["hosts"], dumps(["10.0.0.10"]))
+                        self.assertEqual(internal_api_data["hosts"], dumps(["10.0.0.10"]))
+                    else:
+                        self.assertNotIn("hosts", http_data)
+                        self.assertNotIn("hosts", temporal_data)
+                        self.assertNotIn("hosts", internal_api_data)
 
                 if https_enabled:
                     https_data = harness.get_relation_data(https_rel_id, harness.charm.app.name)
                     self.assertEqual(https_data["port"], str(MAAS_TLS_PROXY_PORT))
                     self.assertEqual(https_data["backend_port"], str(MAAS_HTTPS_PORT))
-
-                    # hosts are empty if the topology is invalid
-                    if http_enabled and tls_enabled:
+                    # hosts are only set if topology is valid
+                    if valid:
                         self.assertEqual(https_data["hosts"], dumps(["10.0.0.10"]))
                     else:
                         self.assertNotIn("hosts", https_data)
@@ -428,6 +470,85 @@ class TestClusterUpdates(unittest.TestCase):
                     self.assertEqual(harness.model.unit.status, ops.ActiveStatus())
                 else:
                     self.assertNotEqual(harness.model.unit.status, ops.ActiveStatus())
+
+    @patch("charm.MaasHelper", autospec=True)
+    def test_haproxy_relation__reported_statuses(self, mock_helper):
+        mock_helper.get_installed_version.return_value = "mock-ver"
+        mock_helper.get_installed_channel.return_value = MAAS_SNAP_CHANNEL
+
+        cases = [
+            # (maas_tls, relations, expected_status_message)
+            (
+                False,
+                [HAPROXY_TLS],
+                "Invalid HAProxy configuration: "
+                f"Cannot have `{HAPROXY_TLS}` relation when MAAS TLS is not enabled; "
+                "Set the `ssl_cert_content` and `ssl_key_content` configuration options.",
+            ),
+            (
+                True,
+                [HAPROXY_NON_TLS, HAPROXY_TEMPORAL, HAPROXY_INTERNAL_HTTP_API],
+                f"Invalid HAProxy configuration: Missing `{HAPROXY_TLS}` relation "
+                "when MAAS TLS is enabled.",
+            ),
+            (
+                True,
+                [HAPROXY_TLS],
+                "Invalid HAProxy configuration: "
+                f"`{HAPROXY_TLS}` relation requires all base relations: "
+                f"`{HAPROXY_NON_TLS}`, `{HAPROXY_TEMPORAL}`, and `{HAPROXY_INTERNAL_HTTP_API}`.",
+            ),
+            (
+                False,
+                [HAPROXY_NON_TLS],
+                "Invalid HAProxy configuration: "
+                f"All of `{HAPROXY_NON_TLS}`, `{HAPROXY_TEMPORAL}`, and `{HAPROXY_INTERNAL_HTTP_API}` "
+                "relations must be present together if any are provided.",
+            ),
+            (
+                False,
+                [HAPROXY_TEMPORAL],
+                "Invalid HAProxy configuration: "
+                f"All of `{HAPROXY_NON_TLS}`, `{HAPROXY_TEMPORAL}`, and `{HAPROXY_INTERNAL_HTTP_API}` "
+                "relations must be present together if any are provided.",
+            ),
+            (
+                False,
+                [HAPROXY_INTERNAL_HTTP_API],
+                "Invalid HAProxy configuration: "
+                f"All of `{HAPROXY_NON_TLS}`, `{HAPROXY_TEMPORAL}`, and `{HAPROXY_INTERNAL_HTTP_API}` "
+                "relations must be present together if any are provided.",
+            ),
+        ]
+
+        for maas_tls, relations, expected_msg in cases:
+            with self.subTest(maas_tls=maas_tls, relations=relations):
+                harness = self._make_harness()
+                harness.add_relation("initialize", "maas-region")
+                harness.set_leader(True)
+                if maas_tls:
+                    harness.update_config(
+                        {
+                            "ssl_cert_content": "placeholder-cert",
+                            "ssl_key_content": "placeholder-key",
+                        }
+                    )
+                harness.begin()
+                db_rel = harness.add_relation(MAAS_DB_NAME, "postgresql")
+                harness.update_relation_data(
+                    db_rel,
+                    "postgresql",
+                    {
+                        "endpoints": "30.0.0.1:5432",
+                        "username": "test_maas_db",
+                        "password": "my_secret",
+                    },
+                )
+                for rel_name in relations:
+                    rel_id = harness.add_relation(rel_name, "haproxy")
+                    harness.add_relation_unit(rel_id, "haproxy/0")
+                harness.evaluate_status()
+                self.assertEqual(harness.model.unit.status, ops.BlockedStatus(expected_msg))
 
 
 class TestCharmActions(unittest.TestCase):

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -5,6 +5,7 @@
 
 import subprocess
 import unittest
+from ipaddress import ip_address
 from json import dumps
 from unittest.mock import PropertyMock, call, patch
 
@@ -346,7 +347,7 @@ class TestClusterUpdates(unittest.TestCase):
             configure_hosts.assert_called_once()
 
             args = configure_hosts.call_args.args
-            self.assertEqual(args, (["10.0.0.10"],))
+            self.assertEqual(args, ([ip_address("10.0.0.10")],))
 
             self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
 
@@ -383,7 +384,7 @@ class TestClusterUpdates(unittest.TestCase):
 
             args = configure_hosts.call_args.args
 
-            self.assertEqual(args, (["10.0.0.10"],))
+            self.assertEqual(args, ([ip_address("10.0.0.10")],))
 
             self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
 

--- a/maas-region/tests/unit/test_helper.py
+++ b/maas-region/tests/unit/test_helper.py
@@ -3,6 +3,7 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
+import subprocess
 import unittest
 from unittest.mock import MagicMock, PropertyMock, mock_open, patch
 
@@ -137,6 +138,101 @@ class TestHelperFiles(unittest.TestCase):
     @patch("pathlib.Path.open", side_effect=OSError)
     def test_get_maas_secret_not_initialised(self, _):
         self.assertIsNone(MaasHelper.get_maas_secret())
+
+    @patch("helper.subprocess.check_output")
+    def test_get_maas_status(self, mock_check_output):
+        mock_output = """Service          Startup   Current   Since
+agent            disabled  active    today at 07:48 UTC
+apiserver        enabled   active    today at 07:48 UTC
+bind9            disabled  inactive  -
+rackd            enabled   error     today at 07:50 UTC
+regiond          enabled   backoff   today at 07:49 UTC
+"""
+        mock_check_output.return_value = mock_output.encode()
+        result = MaasHelper.get_maas_status()
+        self.assertEqual(len(result), 5)
+        self.assertIn("agent", result)
+        self.assertEqual(result["agent"]["startup"], "disabled")
+        self.assertEqual(result["agent"]["current"], "active")
+        self.assertEqual(result["agent"]["since"], "today at 07:48 UTC")
+        self.assertIn("apiserver", result)
+        self.assertIn("bind9", result)
+        self.assertEqual(result["bind9"]["current"], "inactive")
+        self.assertEqual(result["rackd"]["current"], "error")
+        self.assertEqual(result["regiond"]["current"], "backoff")
+        mock_check_output.assert_called_once_with(
+            ["/snap/bin/maas", "status"], stderr=subprocess.DEVNULL
+        )
+
+    @patch("helper.subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "cmd"))
+    def test_get_maas_status_command_failed(self, mock_check_output):
+        result = MaasHelper.get_maas_status()
+        self.assertEqual(result, {})
+
+    @patch("helper.subprocess.check_output")
+    def test_get_maas_status_empty_output(self, mock_check_output):
+        mock_check_output.return_value = b""
+        result = MaasHelper.get_maas_status()
+        self.assertEqual(result, {})
+
+    @patch("helper.subprocess.check_output")
+    def test_get_maas_status_invalid_headers(self, mock_check_output):
+        mock_output = """Service  Status  Other
+agent    enabled  active
+"""
+        mock_check_output.return_value = mock_output.encode()
+        result = MaasHelper.get_maas_status()
+        self.assertEqual(result, {})
+
+    @patch("helper.subprocess.check_output")
+    def test_get_maas_status_invalid_startup(self, mock_check_output):
+        mock_output = """Service  Startup  Current  Since
+agent    unknown  active   today at 07:48 UTC
+"""
+        mock_check_output.return_value = mock_output.encode()
+        result = MaasHelper.get_maas_status()
+        self.assertEqual(result, {})
+
+    @patch("helper.subprocess.check_output")
+    def test_get_maas_status_invalid_status(self, mock_check_output):
+        mock_output = """Service  Startup   Current  Since
+agent    enabled   unknown  today at 07:48 UTC
+"""
+        mock_check_output.return_value = mock_output.encode()
+        result = MaasHelper.get_maas_status()
+        self.assertEqual(result, {})
+
+    @patch("helper.subprocess.check_output")
+    def test_get_maas_status_malformed_line(self, mock_check_output):
+        mock_output = """Service  Startup  Current  Since
+agent    enabled  active   today at 07:48 UTC
+apiserver
+regiond  enabled  active   today at 07:48 UTC
+"""
+        mock_check_output.return_value = mock_output.encode()
+        result = MaasHelper.get_maas_status()
+        # Should skip the malformed line but keep the valid ones
+        self.assertEqual(len(result), 2)
+        self.assertIn("agent", result)
+        self.assertIn("regiond", result)
+        self.assertNotIn("apiserver", result)
+
+    @patch("helper.subprocess.check_output")
+    def test_get_maas_status_mixed_valid_invalid(self, mock_check_output):
+        mock_output = """Service    Startup   Current   Since
+agent      disabled  active    today at 07:48 UTC
+apiserver  invalid   active    today at 07:48 UTC
+regiond    enabled   unknown   today at 07:48 UTC
+rackd      enabled   active    today at 07:48 UTC
+"""
+        mock_check_output.return_value = mock_output.encode()
+        result = MaasHelper.get_maas_status()
+        # Should only include valid entries
+        self.assertEqual(len(result), 2)
+        self.assertIn("agent", result)
+        self.assertIn("rackd", result)
+        self.assertNotIn("apiserver", result)
+        self.assertNotIn("regiond", result)
 
 
 class TestHelperSetup(unittest.TestCase):


### PR DESCRIPTION
- ci: explicitly set the permissions needed for observability reusable workflows (#605)
- chore(deps): update dependency pydantic to v2.13.4 (#602)
- chore(deps): update botocore to >=1.43.11, <1.44.0 (#601)
- chore: update charm libraries (#604)
- chore: update charm libraries (#603)
- fix: properly calculate MAAS URL (#599)
- fix: set backend server timeout (#598)
- chore(deps): update dependency pydantic to v2.13.3 (#596)
- chore: use correct type for configure_hosts (#595)
- chore: update charm libraries (#594)
- feat: Added Temporal and Internal HTTP API ports to HAProxy (#593)
- feat: add MAAS status action (#592)
- fix: properly operate maas-region when integrated with haproxy (#584)
- fix: 585 cannot restore backup (#586)
- chore: update charm libraries (#582)
- feat: Implement MAAS HAProxy TCP relations (#571)