### PR TITLE
ci: fix lint and format issues

### DIFF
--- a/maas-region/tox.ini
+++ b/maas-region/tox.ini
@@ -9,9 +9,9 @@ env_list =
     scenario
 no_package = true
 skip_missing_interpreters = true
-basepython = py310
 
 [testenv]
+base_python = py310
 pass_env =
     CHARM_BUILD_DIR
     MODEL_SETTINGS
@@ -26,6 +26,7 @@ description = Apply coding style standards to code
 deps =
     pyproject-fmt
     ruff
+    toml-fmt-common<1.3.3
     tox-ini-fmt
 commands =
     ruff format {[vars]all_path}
@@ -39,6 +40,7 @@ deps =
     codespell
     pyproject-fmt
     ruff
+    toml-fmt-common<1.3.3
 commands =
     codespell {tox_root}
     ruff check {[vars]all_path}


### PR DESCRIPTION
- Move basepython from [tox] (invalid in tox 4) to [testenv] as base_python = py310
- Pin toml-fmt-common<1.3.3 in format/lint environments to work around pyproject-fmt --table-format argparse conflict