### PR TITLE
ci/update release ci job version and permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Release MAAS Region charm to edge
     needs: detect-region-changes
     if: needs.detect-region-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-release.yaml@632d811436c708a897389e0419fefc87808637be  # Branch v0
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
     permissions:
       security-events: write
       actions: read
-      contents: read
+      contents: write
     secrets: inherit
     with:
       charm-path: maas-region


### PR DESCRIPTION
This enables us to upload to charmhub, see here for further details https://github.com/canonical/observability/pull/455