### PR TITLE
ci/update release ci job version and permissions (#617)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,11 +34,11 @@ jobs:
     name: Release MAAS Region charm to edge
     needs: detect-region-changes
     if: needs.detect-region-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-release.yaml@632d811436c708a897389e0419fefc87808637be  # Branch v0
     permissions:
       security-events: write
       actions: read
-      contents: read
+      contents: write
     secrets: inherit
     with:
       charm-path: maas-region


### PR DESCRIPTION
* chore: update charm-release.yaml sha

This updates it to the latest version containing fixes enabling backport to 3.7. More details here:

https://github.com/canonical/observability/pull/455

* chore: permissions content from read->write for release job