### PR TITLE
ci: properly set charmcraft channel on release

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@52031bd3ea837bc1836ca52bae01bd263e9213fd # Branch v0
     with:
       charm-path: ${{ github.event.inputs.charm }}
       promotion: ${{ github.event.inputs.promotion }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   pull-request-region:
     name: PR Region
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@52031bd3ea837bc1836ca52bae01bd263e9213fd # Branch v0
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Release MAAS Region charm to edge
     needs: detect-region-changes
     if: needs.detect-region-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@632d811436c708a897389e0419fefc87808637be  # Branch v0
+    uses: canonical/observability/.github/workflows/charm-release.yaml@52031bd3ea837bc1836ca52bae01bd263e9213fd # Branch v0
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-lib-region:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@5e76ffc10eb6b4b2c6b7537e1d1398b64ee438d4 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@52031bd3ea837bc1836ca52bae01bd263e9213fd # Branch v0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Bump observability commit SHA to include a fix to properly consume charmcraft channel in the release GH workflow. Also bump the commit in every other action to match.