### PR TITLE
fix: properly add library labels to PRs

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@52031bd3ea837bc1836ca52bae01bd263e9213fd # Branch v0
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@ec942dec1412fed70466189e257337ecad08fa87 # Branch v0
     with:
       charm-path: ${{ github.event.inputs.charm }}
       promotion: ${{ github.event.inputs.promotion }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,11 +9,12 @@ on:
 jobs:
   pull-request-region:
     name: PR Region
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@52031bd3ea837bc1836ca52bae01bd263e9213fd # Branch v0
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@ec942dec1412fed70466189e257337ecad08fa87 # Branch v0
     permissions:
       security-events: write
       actions: read
       contents: write
+      issues: write
     secrets: inherit
     with:
       charm-path: maas-region

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Release MAAS Region charm to edge
     needs: detect-region-changes
     if: needs.detect-region-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@52031bd3ea837bc1836ca52bae01bd263e9213fd # Branch v0
+    uses: canonical/observability/.github/workflows/charm-release.yaml@ec942dec1412fed70466189e257337ecad08fa87 # Branch v0
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-lib-region:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@52031bd3ea837bc1836ca52bae01bd263e9213fd # Branch v0
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@ec942dec1412fed70466189e257337ecad08fa87 # Branch v0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Bump the observability commit to include a fix that is setting proper token permissions to allow the PR CI to add library labels to PRs. Also set the permission accordingly to `issues: write`, to allow the GH action to successfully set them [here](https://github.com/canonical/charming-actions/blob/2.5.0-rc/dist/check-libraries/index.js#L8792)