### PR TITLE
ci: do not report library statuses with GH labels

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@ec942dec1412fed70466189e257337ecad08fa87 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@3414ea10e5fd0c10246c07937a3f621ff54cadc2 # Branch v0
     with:
       charm-path: ${{ github.event.inputs.charm }}
       promotion: ${{ github.event.inputs.promotion }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   pull-request-region:
     name: PR Region
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@ec942dec1412fed70466189e257337ecad08fa87 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@3414ea10e5fd0c10246c07937a3f621ff54cadc2 # Branch v0
     permissions:
       security-events: write
       actions: read
@@ -22,3 +22,4 @@ jobs:
       python-version: "3.10"
       provider: lxd
       charmcraft-channel: latest/stable
+      check-library-labels: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,7 @@ jobs:
       security-events: write
       actions: read
       contents: write
+      issues: write
     secrets: inherit
     with:
       charm-path: maas-region

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Release MAAS Region charm to edge
     needs: detect-region-changes
     if: needs.detect-region-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@ec942dec1412fed70466189e257337ecad08fa87 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-release.yaml@3414ea10e5fd0c10246c07937a3f621ff54cadc2 # Branch v0
     permissions:
       security-events: write
       actions: read
@@ -48,3 +48,4 @@ jobs:
       provider: lxd
       build-for-arm: true
       charmcraft-channel: latest/stable
+      check-library-labels: false

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-lib-region:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@ec942dec1412fed70466189e257337ecad08fa87 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@3414ea10e5fd0c10246c07937a3f621ff54cadc2 # Branch v0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
The feature of labeling PRs for the status of the charm libraries is not working very well with PRs from forks. As it is not bringing any value for the maas-region charm, this PR is disabling it. To make it happen, we have to bumb to a observability commit that allows it.