### PR TITLE
fix: regenerate Prometheus scrape configs when TLS config changes

### DIFF
--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -203,21 +203,12 @@ class MaasRegionCharm(ops.CharmBase):
         )
 
         # COS
-        endpoints: list[cos_agent._MetricsEndpointDict] = [
-            {"path": "/metrics", "port": MAAS_REGION_METRICS_PORT},
-            {"path": "/MAAS/metrics", "port": MAAS_CLUSTER_METRICS_PORT},
-            {"path": "/metrics/temporal", "port": MAAS_HTTP_PORT},
-        ]
-        if self.config["enable_rack_mode"]:
-            endpoints.append(
-                {"path": MAAS_AGENT_METRICS_ENDPOINT, "port": MAAS_AGENT_METRICS_PORT}
-            )
         self._grafana_agent = cos_agent.COSAgentProvider(
             self,
-            metrics_endpoints=endpoints,
             metrics_rules_dir="./src/prometheus",
             logs_rules_dir="./src/loki",
             dashboard_dirs=["./src/grafana_dashboards"],
+            scrape_configs=self._generate_scrape_configs,
         )
         self.tracing = TracingEndpointRequirer(self, protocols=["otlp_http"])
         self.charm_tracing_endpoint, _ = charm_tracing_config(self.tracing, None)
@@ -397,6 +388,74 @@ class MaasRegionCharm(ops.CharmBase):
             return {}
         data = self.peers.data[app_or_unit].get(key, "")
         return json.loads(data) if data else {}
+
+    def _generate_scrape_configs(self) -> list[dict]:
+        """Build Prometheus scrape_configs for the cos-agent relation.
+
+        The scheme/port of some MAAS metrics endpoints depend on whether TLS is
+        enabled, so they are generated dynamically. The COSAgentProvider invokes
+        this callable on each of its refresh events, which by default include this
+        (maas-region) charm's ``config_changed`` plus cos-agent relation changes.
+        So toggling the ``ssl_*`` config options regenerates the scrape jobs.
+
+        Returns:
+            list[dict]: standard Prometheus scrape_config dicts
+        """
+        # The region metrics endpoint is plain http and identical in both modes.
+        scrape_configs: list[dict] = [
+            {
+                "metrics_path": "/metrics",
+                "static_configs": [{"targets": [f"localhost:{MAAS_REGION_METRICS_PORT}"]}],
+            },
+        ]
+
+        # /MAAS/metrics and /metrics/temporal move from http:5240 to https:5443
+        # when TLS is enabled.
+        if self.is_tls_config_enabled:
+            # We include insecure_skip_verify because we are always scraping localhost.
+            # Even if we have the certs for the scrape targets, we'd rather specify the scrape
+            # jobs with localhost rather than the SAN (region/HAProxy IP) the cert was issued for.
+            tls_config = {"insecure_skip_verify": True}
+            scrape_configs.append(
+                {
+                    "scheme": "https",
+                    "metrics_path": "/MAAS/metrics",
+                    "static_configs": [{"targets": [f"localhost:{MAAS_HTTPS_PORT}"]}],
+                    "tls_config": tls_config,
+                }
+            )
+            scrape_configs.append(
+                {
+                    "scheme": "https",
+                    "metrics_path": "/metrics/temporal",
+                    "static_configs": [{"targets": [f"localhost:{MAAS_HTTPS_PORT}"]}],
+                    "tls_config": tls_config,
+                }
+            )
+        else:
+            scrape_configs.append(
+                {
+                    "metrics_path": "/MAAS/metrics",
+                    "static_configs": [{"targets": [f"localhost:{MAAS_CLUSTER_METRICS_PORT}"]}],
+                }
+            )
+            scrape_configs.append(
+                {
+                    "metrics_path": "/metrics/temporal",
+                    "static_configs": [{"targets": [f"localhost:{MAAS_HTTP_PORT}"]}],
+                }
+            )
+
+        # Agent metrics are plain http and only present in rack mode.
+        if self.config["enable_rack_mode"]:
+            scrape_configs.append(
+                {
+                    "metrics_path": MAAS_AGENT_METRICS_ENDPOINT,
+                    "static_configs": [{"targets": [f"localhost:{MAAS_AGENT_METRICS_PORT}"]}],
+                }
+            )
+
+        return scrape_configs
 
     def _setup_network(self) -> bool:
         """Open the network ports.

--- a/maas-region/tests/integration/test_charm.py
+++ b/maas-region/tests/integration/test_charm.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 import asyncio
+import json
 import logging
 import re
 from pathlib import Path
@@ -187,14 +188,30 @@ async def test_haproxy_integration(ops_test: OpsTest, tmp_path):
         apps=["haproxy", APP_NAME], status="active", raise_on_blocked=True, timeout=3600
     )
 
-    address = await ops_test.model.applications[APP_NAME].units[0].get_public_address()
-    haproxy_address = await ops_test.model.applications["haproxy"].units[0].get_public_address()
-
-    key, cacert, cert = generate_cert(ip_addresses=[address, haproxy_address], tmp_path=tmp_path)
     await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp", "haproxy")
     await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp-temporal", "haproxy")
     await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp-internal-http-api", "haproxy")
     await ops_test.model.integrate(f"{APP_NAME}:ingress-tcp-tls", "haproxy")
+    await ops_test.model.wait_for_idle(
+        apps=["haproxy"], status="active", raise_on_blocked=True, timeout=3600
+    )
+
+    address = await ops_test.model.applications[APP_NAME].units[0].get_public_address()
+    _, stdout, _ = await ops_test.juju("show-unit", f"{APP_NAME}/0", "--format", "json")
+    relation_info = json.loads(stdout)[f"{APP_NAME}/0"]["relation-info"]
+    haproxy_address = None
+    for relation in relation_info:
+        if relation["endpoint"] != "ingress-tcp":
+            continue
+        raw_endpoints = relation["application-data"]["endpoints"]
+        endpoints = json.loads(raw_endpoints)
+        # endpoints is a list of "ip:port" strings, e.g. ["10.226.71.117:80"]
+        haproxy_address = endpoints[0].rsplit(":", 1)[0]
+        break
+    assert haproxy_address, "Could not find HAProxy address on the ingress-tcp relation"
+
+    key, cacert, cert = generate_cert(ip_addresses=[address, haproxy_address], tmp_path=tmp_path)
+
     await ops_test.model.applications[APP_NAME].set_config({"ssl_cert_content": cert})
     await ops_test.model.applications[APP_NAME].set_config({"ssl_key_content": key})
     await ops_test.model.applications[APP_NAME].set_config({"ssl_cacert_content": cacert})

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -19,12 +19,16 @@ from charm import (
     HAPROXY_NON_TLS,
     HAPROXY_TEMPORAL,
     HAPROXY_TLS,
+    MAAS_AGENT_METRICS_ENDPOINT,
+    MAAS_AGENT_METRICS_PORT,
+    MAAS_CLUSTER_METRICS_PORT,
     MAAS_DB_NAME,
     MAAS_HTTP_PORT,
     MAAS_HTTPS_PORT,
     MAAS_INTERNAL_HTTP_API_PORT,
     MAAS_PEER_NAME,
     MAAS_PROXY_PORT,
+    MAAS_REGION_METRICS_PORT,
     MAAS_SNAP_CHANNEL,
     MAAS_TEMPORAL_PORT,
     MAAS_TLS_PROXY_PORT,
@@ -844,3 +848,92 @@ class TestMAASURLs(unittest.TestCase):
                 self.harness.cleanup()
                 self.harness = ops.testing.Harness(MaasRegionCharm)
                 self.harness.add_network("10.0.0.10")
+
+
+class TestScrapeConfigs(unittest.TestCase):
+    def setUp(self):
+        self.harness = ops.testing.Harness(MaasRegionCharm)
+        self.harness.add_network("10.0.0.10")
+        self.addCleanup(self.harness.cleanup)
+
+    @staticmethod
+    def _by_path(scrape_configs):
+        return {cfg["metrics_path"]: cfg for cfg in scrape_configs}
+
+    def test_non_tls_mode(self):
+        """All MAAS endpoints are scraped over http when TLS is disabled."""
+        self.harness.update_config({"enable_rack_mode": False})
+        self.harness.begin()
+
+        configs = self.harness.charm._generate_scrape_configs()
+        by_path = self._by_path(configs)
+
+        self.assertEqual(set(by_path), {"/metrics", "/MAAS/metrics", "/metrics/temporal"})
+        # No https scheme nor tls_config in non-TLS mode.
+        for cfg in configs:
+            self.assertNotIn("scheme", cfg)
+            self.assertNotIn("tls_config", cfg)
+        self.assertEqual(
+            by_path["/metrics"]["static_configs"][0]["targets"],
+            [f"localhost:{MAAS_REGION_METRICS_PORT}"],
+        )
+        self.assertEqual(
+            by_path["/MAAS/metrics"]["static_configs"][0]["targets"],
+            [f"localhost:{MAAS_CLUSTER_METRICS_PORT}"],
+        )
+        self.assertEqual(
+            by_path["/metrics/temporal"]["static_configs"][0]["targets"],
+            [f"localhost:{MAAS_HTTP_PORT}"],
+        )
+
+    def test_tls_mode(self):
+        """/MAAS/metrics and /metrics/temporal move to https:5443 when TLS is enabled."""
+        self.harness.update_config(
+            {
+                "enable_rack_mode": False,
+                "ssl_cert_content": "placeholder-cert",
+                "ssl_key_content": "placeholder-key",
+            }
+        )
+        self.harness.begin()
+
+        configs = self.harness.charm._generate_scrape_configs()
+        by_path = self._by_path(configs)
+
+        self.assertEqual(set(by_path), {"/metrics", "/MAAS/metrics", "/metrics/temporal"})
+        # The region metrics endpoint stays plain http.
+        self.assertNotIn("scheme", by_path["/metrics"])
+        self.assertEqual(
+            by_path["/metrics"]["static_configs"][0]["targets"],
+            [f"localhost:{MAAS_REGION_METRICS_PORT}"],
+        )
+        for path in ("/MAAS/metrics", "/metrics/temporal"):
+            cfg = by_path[path]
+            self.assertEqual(cfg["scheme"], "https")
+            self.assertEqual(cfg["tls_config"], {"insecure_skip_verify": True})
+            self.assertEqual(cfg["static_configs"][0]["targets"], [f"localhost:{MAAS_HTTPS_PORT}"])
+
+    def test_rack_mode_adds_agent_endpoint(self):
+        """Rack mode adds the http agent metrics endpoint."""
+        self.harness.update_config({"enable_rack_mode": True})
+        self.harness.begin()
+
+        configs = self.harness.charm._generate_scrape_configs()
+        by_path = self._by_path(configs)
+
+        self.assertIn(MAAS_AGENT_METRICS_ENDPOINT, by_path)
+        agent_cfg = by_path[MAAS_AGENT_METRICS_ENDPOINT]
+        self.assertNotIn("scheme", agent_cfg)
+        self.assertEqual(
+            agent_cfg["static_configs"][0]["targets"],
+            [f"localhost:{MAAS_AGENT_METRICS_PORT}"],
+        )
+
+    def test_rack_mode_disabled_omits_agent_endpoint(self):
+        """Without rack mode the agent metrics endpoint is not scraped."""
+        self.harness.update_config({"enable_rack_mode": False})
+        self.harness.begin()
+
+        by_path = self._by_path(self.harness.charm._generate_scrape_configs())
+
+        self.assertNotIn(MAAS_AGENT_METRICS_ENDPOINT, by_path)


### PR DESCRIPTION
## What

The MAAS region charm now builds its Prometheus scrape configs dynamically via a
callable passed to `COSAgentProvider`. When TLS config (`ssl_*`) changes, the
scrape jobs are regenerated with the correct scheme (http/https) and port,
instead of being fixed at startup. Added unit tests (`TestScrapeConfigs`) covering
TLS, non-TLS, and rack modes.

## Integration tests

Updated `test_haproxy_integration` to wait for HAProxy to settle after relating,
then resolve the HAProxy address from the `ingress-tcp` relation's published
`endpoints` data (instead of the unit's public address) before generating certs.

Resolves: #626 