### PR TITLE
chore: bump CI to actions that are using node 24

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@3414ea10e5fd0c10246c07937a3f621ff54cadc2 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@4ffb7e29487fd047f6b88e833aaf22ceaad0430e # Branch v0
     with:
       charm-path: ${{ github.event.inputs.charm }}
       promotion: ${{ github.event.inputs.promotion }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   pull-request-region:
     name: PR Region
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@3414ea10e5fd0c10246c07937a3f621ff54cadc2 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@4ffb7e29487fd047f6b88e833aaf22ceaad0430e # Branch v0
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - name: Determine changed files in the commit
         id: changed-files
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # Version 46.0.1
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # Version 47.0.6
         with:
           files: |
             maas-region/**
@@ -34,7 +34,7 @@ jobs:
     name: Release MAAS Region charm to edge
     needs: detect-region-changes
     if: needs.detect-region-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@3414ea10e5fd0c10246c07937a3f621ff54cadc2 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-release.yaml@4ffb7e29487fd047f6b88e833aaf22ceaad0430e # Branch v0
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-lib-region:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@3414ea10e5fd0c10246c07937a3f621ff54cadc2 # Branch v0
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@4ffb7e29487fd047f6b88e833aaf22ceaad0430e # Branch v0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
- Bump observability to include changes from https://github.com/canonical/observability/commit/4ffb7e29487fd047f6b88e833aaf22ceaad0430e
- Bump `tj-actions/changed-files` to latest version