### PR TITLE
chore: bump observability CI

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@4ffb7e29487fd047f6b88e833aaf22ceaad0430e # Branch v0
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@c8b90c2e6dea32e59a5deb089c3e76565bdee8b3 # Branch v0
     with:
       charm-path: ${{ github.event.inputs.charm }}
       promotion: ${{ github.event.inputs.promotion }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   pull-request-region:
     name: PR Region
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@4ffb7e29487fd047f6b88e833aaf22ceaad0430e # Branch v0
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@c8b90c2e6dea32e59a5deb089c3e76565bdee8b3 # Branch v0
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Release MAAS Region charm to edge
     needs: detect-region-changes
     if: needs.detect-region-changes.outputs.any_changed == 'true'
-    uses: canonical/observability/.github/workflows/charm-release.yaml@4ffb7e29487fd047f6b88e833aaf22ceaad0430e # Branch v0
+    uses: canonical/observability/.github/workflows/charm-release.yaml@c8b90c2e6dea32e59a5deb089c3e76565bdee8b3 # Branch v0
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-lib-region:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@4ffb7e29487fd047f6b88e833aaf22ceaad0430e # Branch v0
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@c8b90c2e6dea32e59a5deb089c3e76565bdee8b3 # Branch v0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
- Allow running integration tests with desired Python version
- Remove some node20 deprecation warnings