### PR TITLE
fix: charm stuck starting

### DIFF
--- a/maas-region/src/backups.py
+++ b/maas-region/src/backups.py
@@ -33,7 +33,7 @@ from botocore.regions import EndpointResolver
 from charms.data_platform_libs.v0.s3 import CredentialsChangedEvent, S3Requirer
 from ops.charm import ActionEvent
 from ops.framework import Object
-from ops.model import ActiveStatus, MaintenanceStatus
+from ops.model import MaintenanceStatus
 
 from helper import MaasHelper
 
@@ -482,7 +482,10 @@ class MAASBackups(Object):
             return
 
     def _on_s3_credential_gone(self, event) -> None:
-        if self.charm.is_blocked:
+        if (
+            self.charm.is_blocked
+            and self.charm.unit.status.message in S3_BLOCK_MESSAGES
+        ):
             self.charm.set_peer_data(self.charm.app, S3_CONFIGURATION_BLOCKED_KEY, "")
 
     def _on_create_backup_action(self, event) -> None:
@@ -743,8 +746,6 @@ Juju Version: {self.charm.model.juju_version!s}
         )
 
         event.log("Region restore complete")
-
-        self.charm.unit.status = ActiveStatus()
         event.set_results({"restore-status": "restore finished"})
 
     def _run_restore(

--- a/maas-region/src/backups.py
+++ b/maas-region/src/backups.py
@@ -52,7 +52,7 @@ SNAP_PATH_TO_PRESEEDS = "/var/snap/maas/current/preseeds"
 METADATA_PATH = "backup/latest"
 REFER_TO_DEBUG_LOG = " Please check the juju debug-log for more details."
 MAAS_REGION_RELATION = "maas-cluster"
-
+S3_CONFIGURATION_BLOCKED_KEY = "s3-configuration-blocked-message"
 # filenames
 MODEL_UUID_FILENAME = "model-uuid.txt"
 METADATA_FILENAME = "backup_metadata.json"
@@ -465,6 +465,8 @@ class MAASBackups(Object):
         if not self.charm.unit.is_leader():
             return
 
+        self.charm.set_peer_data(self.charm.app, S3_CONFIGURATION_BLOCKED_KEY, "")
+
         s3_parameters, _ = self._retrieve_s3_parameters()
         if not s3_parameters:
             return
@@ -472,14 +474,16 @@ class MAASBackups(Object):
         try:
             self._create_bucket_if_not_exists(s3_parameters)
         except (ClientError, ValueError, ParamValidationError, SSLError):
-            self.charm.unit.status = BlockedStatus(FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE)
+            self.charm.set_peer_data(
+                self.charm.app,
+                S3_CONFIGURATION_BLOCKED_KEY,
+                FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE,
+            )
             return
-
-        self.charm.unit.status = ActiveStatus()
 
     def _on_s3_credential_gone(self, event) -> None:
         if self.charm.is_blocked and self.charm.unit.status.message in S3_BLOCK_MESSAGES:
-            self.charm.unit.status = ActiveStatus()
+            self.charm.set_peer_data(self.charm.app, S3_CONFIGURATION_BLOCKED_KEY, "")
 
     def _on_create_backup_action(self, event) -> None:
         can_unit_perform_backup, validation_message = self._can_unit_perform_backup()

--- a/maas-region/src/backups.py
+++ b/maas-region/src/backups.py
@@ -33,7 +33,7 @@ from botocore.regions import EndpointResolver
 from charms.data_platform_libs.v0.s3 import CredentialsChangedEvent, S3Requirer
 from ops.charm import ActionEvent
 from ops.framework import Object
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+from ops.model import ActiveStatus, MaintenanceStatus
 
 from helper import MaasHelper
 
@@ -482,7 +482,7 @@ class MAASBackups(Object):
             return
 
     def _on_s3_credential_gone(self, event) -> None:
-        if self.charm.is_blocked and self.charm.unit.status.message in S3_BLOCK_MESSAGES:
+        if self.charm.is_blocked:
             self.charm.set_peer_data(self.charm.app, S3_CONFIGURATION_BLOCKED_KEY, "")
 
     def _on_create_backup_action(self, event) -> None:

--- a/maas-region/src/backups.py
+++ b/maas-region/src/backups.py
@@ -518,8 +518,6 @@ Juju Version: {self.charm.model.juju_version!s}
 
         self._run_backup(event, s3_parameters)
 
-        self.charm.unit.status = ActiveStatus()
-
     def _run_backup(
         self,
         event: ActionEvent,

--- a/maas-region/src/backups.py
+++ b/maas-region/src/backups.py
@@ -43,9 +43,6 @@ BACKUP_ID_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE = (
     "failed to access/create the bucket, check your S3 settings"
 )
-S3_BLOCK_MESSAGES = [
-    FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE,
-]
 SNAP_PATH_TO_IDS = "/var/snap/maas/common/maas/maas_id"
 SNAP_PATH_TO_IMAGES = "/var/snap/maas/common/maas/image-storage"
 SNAP_PATH_TO_PRESEEDS = "/var/snap/maas/current/preseeds"
@@ -482,10 +479,10 @@ class MAASBackups(Object):
             return
 
     def _on_s3_credential_gone(self, event) -> None:
-        if (
-            self.charm.is_blocked
-            and self.charm.unit.status.message in S3_BLOCK_MESSAGES
-        ):
+        if not self.charm.unit.is_leader():
+            return
+
+        if self.charm.get_peer_data(self.charm.app, S3_CONFIGURATION_BLOCKED_KEY):
             self.charm.set_peer_data(self.charm.app, S3_CONFIGURATION_BLOCKED_KEY, "")
 
     def _on_create_backup_action(self, event) -> None:

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -686,16 +686,18 @@ class MaasRegionCharm(ops.CharmBase):
     def _on_collect_status(self, e: ops.CollectStatusEvent) -> None:
         if MaasHelper.get_installed_channel() != MAAS_SNAP_CHANNEL:
             e.add_status(ops.BlockedStatus("Failed to install MAAS snap"))
+        elif (
+            # If the S3 configuration is marked as blocked in the application data bag,
+            # mark the leader as blocked.
+            blocked_msg := self.get_peer_data(self.app, S3_CONFIGURATION_BLOCKED_KEY)
+        ) and self.unit.is_leader():
+            e.add_status(ops.BlockedStatus(blocked_msg))
         elif not self.unit.opened_ports().issuperset(MAAS_REGION_PORTS):
             e.add_status(ops.WaitingStatus("Waiting for service ports"))
         elif not self.connection_string:
             e.add_status(ops.WaitingStatus("Waiting for database DSN"))
         elif not self.maas_api_url:
             e.add_status(ops.WaitingStatus("Waiting for MAAS initialization"))
-        elif (
-            blocked_msg := self.get_peer_data(self.app, S3_CONFIGURATION_BLOCKED_KEY)
-        ) and self.unit.is_leader():
-            e.add_status(ops.BlockedStatus(blocked_msg))
         else:
             # Check HAProxy configuration validity
             haproxy_non_tls = self.model.get_relation(HAPROXY_NON_TLS) is not None

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -516,7 +516,6 @@ class MaasRegionCharm(ops.CharmBase):
                     self.config["enable_prometheus_metrics"],  # type: ignore
                     str(self.config["ssl_cacert_content"]),
                 )
-            self.unit.status = ops.ActiveStatus()
             return True
         except subprocess.CalledProcessError:
             return False
@@ -552,7 +551,8 @@ class MaasRegionCharm(ops.CharmBase):
         """Configure the two HAProxy relations.
 
         Provides the MAAS Region IP addresses to each HAProxy relation.
-        Sets the unit to an active status if we have a valid relation/configuration topology.
+        Status setting is left to `_on_collect_status`, which evaluates the
+        relation/configuration topology.
 
         Returns:
             None
@@ -592,8 +592,6 @@ class MaasRegionCharm(ops.CharmBase):
         )
 
         if not self.unit.is_leader():
-            if unit_valid:
-                self.unit.status = ops.ActiveStatus()
             return
 
         haproxy_relations = [
@@ -609,9 +607,6 @@ class MaasRegionCharm(ops.CharmBase):
                 else:
                     rel.configure_hosts()
                 rel.update_relation_data()
-
-        if unit_valid:
-            self.unit.status = ops.ActiveStatus()
 
     def _reconcile_ha_proxy_and_initialise(self, event: ops.EventBase) -> None:
         self._reconcile_ha_proxy(event)

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -26,7 +26,7 @@ from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer, cha
 from ops.model import SecretNotFoundError
 from pydantic import IPvAnyAddress
 
-from backups import MAASBackups
+from backups import S3_CONFIGURATION_BLOCKED_KEY, MAASBackups
 from helper import MaasHelper
 
 logger = logging.getLogger(__name__)
@@ -692,6 +692,10 @@ class MaasRegionCharm(ops.CharmBase):
             e.add_status(ops.WaitingStatus("Waiting for database DSN"))
         elif not self.maas_api_url:
             e.add_status(ops.WaitingStatus("Waiting for MAAS initialization"))
+        elif (
+            blocked_msg := self.get_peer_data(self.app, S3_CONFIGURATION_BLOCKED_KEY)
+        ) and self.unit.is_leader():
+            e.add_status(ops.BlockedStatus(blocked_msg))
         else:
             # Check HAProxy configuration validity
             haproxy_non_tls = self.model.get_relation(HAPROXY_NON_TLS) is not None
@@ -745,6 +749,7 @@ class MaasRegionCharm(ops.CharmBase):
                 )
             else:
                 logger.debug("no status change based on prerequisites")
+                e.add_status(ops.ActiveStatus())
 
     def _on_maasdb_created(self, event: db.DatabaseCreatedEvent) -> None:
         """Database is ready.

--- a/maas-region/src/charm.py
+++ b/maas-region/src/charm.py
@@ -745,7 +745,6 @@ class MaasRegionCharm(ops.CharmBase):
                     )
                 )
             else:
-                logger.debug("no status change based on prerequisites")
                 e.add_status(ops.ActiveStatus())
 
     def _on_maasdb_created(self, event: db.DatabaseCreatedEvent) -> None:

--- a/maas-region/tests/unit/test_backup.py
+++ b/maas-region/tests/unit/test_backup.py
@@ -27,6 +27,7 @@ from backups import (
     MAAS_REGION_RELATION,
     METADATA_FILENAME,
     PRESEED_TAR_FILENAME,
+    S3_CONFIGURATION_BLOCKED_KEY,
     SNAP_PATH_TO_IMAGES,
     SNAP_PATH_TO_PRESEEDS,
     DownloadProgressPercentage,
@@ -34,7 +35,7 @@ from backups import (
     UploadProgressPercentage,
     as_size,
 )
-from charm import MaasRegionCharm
+from charm import MAAS_DB_NAME, MAAS_SNAP_CHANNEL, MaasRegionCharm
 
 
 class TestMAASBackups(unittest.TestCase):
@@ -42,6 +43,28 @@ class TestMAASBackups(unittest.TestCase):
         self.harness = ops.testing.Harness(MaasRegionCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.add_relation("initialize", "maas-region")
+
+    def _satisfy_status_ladder(self, mock_helper) -> None:
+        """Set up everything the collect-status ladder needs to reach ActiveStatus.
+
+        Mocks the snap channel and adds a maas-db relation with valid data, so
+        that after ``self.harness.begin()`` + ``self.harness.charm._setup_network()``
+        + ``self.harness.evaluate_status()``, only whatever the test itself
+        controls (e.g. the S3-blocked peer-data flag) determines the final
+        status.
+        """
+        mock_helper.get_installed_channel.return_value = MAAS_SNAP_CHANNEL
+        self.harness.add_network("10.0.0.10")
+        db_rel = self.harness.add_relation(MAAS_DB_NAME, "postgresql")
+        self.harness.update_relation_data(
+            db_rel,
+            "postgresql",
+            {
+                "endpoints": "30.0.0.1:5432",
+                "username": "test_maas_db",
+                "password": "my_secret",
+            },
+        )
 
     @patch("boto3.session.Session.resource")
     @patch("backups.Config")
@@ -479,9 +502,11 @@ backup-id            | action      | status   | maas     | size       | controll
             },
         )
 
+    @patch("charm.MaasHelper", autospec=True)
     @patch("backups.MAASBackups._create_bucket_if_not_exists")
     @patch("backups.MAASBackups._read_content_from_s3")
-    def test_on_s3_credential_changed(self, read_content, create_bucket):
+    def test_on_s3_credential_changed(self, read_content, create_bucket, mock_helper):
+        self._satisfy_status_ladder(mock_helper)
         s3_parameters_dict = {
             "bucket": "test-bucket",
             "region": "test-region",
@@ -493,11 +518,17 @@ backup-id            | action      | status   | maas     | size       | controll
             "delete-older-than-days": "9999999",
         }
         read_content.return_value = None
-        self.harness.begin()
+        # self.harness.add_relation(MAAS_REGION_RELATION, "maas-region")
         self.harness.set_leader(True)
+        self.harness.begin()
+        self.harness.charm._setup_network()
         self.harness.add_relation("s3-parameters", "s3-integrator", app_data=s3_parameters_dict)
         s3_parameters_dict["delete-older-than-days"] = 9999999
         create_bucket.assert_called_once_with(s3_parameters_dict)
+        self.assertFalse(
+            self.harness.charm.get_peer_data(self.harness.charm.app, S3_CONFIGURATION_BLOCKED_KEY)
+        )
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.charm.unit.status, ops.ActiveStatus())
 
     @patch("backups.MAASBackups._create_bucket_if_not_exists")
@@ -529,8 +560,9 @@ backup-id            | action      | status   | maas     | size       | controll
         )
         create_bucket.assert_not_called()
 
+    @patch("charm.MaasHelper.get_installed_channel", return_value=MAAS_SNAP_CHANNEL)
     @patch("backups.MAASBackups._create_bucket_if_not_exists")
-    def test_on_s3_credential_changed__bucket_error(self, create_bucket):
+    def test_on_s3_credential_changed__bucket_error(self, create_bucket, _get_installed_channel):
         s3_parameters_dict = {
             "bucket": "test-bucket",
             "region": "test-region",
@@ -543,10 +575,16 @@ backup-id            | action      | status   | maas     | size       | controll
         }
         create_bucket.side_effect = ValueError()
         self.harness.begin()
+        # self.harness.add_relation(MAAS_REGION_RELATION, "maas-region")
         self.harness.set_leader(True)
         self.harness.add_relation("s3-parameters", "s3-integrator", app_data=s3_parameters_dict)
         s3_parameters_dict["delete-older-than-days"] = 9999999
         create_bucket.assert_called_once_with(s3_parameters_dict)
+        self.assertEqual(
+            self.harness.charm.get_peer_data(self.harness.charm.app, S3_CONFIGURATION_BLOCKED_KEY),
+            FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE,
+        )
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.charm.unit.status,
             ops.BlockedStatus(FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE),
@@ -562,32 +600,46 @@ backup-id            | action      | status   | maas     | size       | controll
             ops.ActiveStatus(),
         )
 
-    def test_on_s3_credential_gone__set_active(self):
+    @patch("charm.MaasHelper", autospec=True)
+    def test_on_s3_credential_gone__set_active(self, mock_helper):
+        self._satisfy_status_ladder(mock_helper)
         rel = self.harness.add_relation("s3-parameters", "s3-integrator")
+        self.harness.add_relation(MAAS_REGION_RELATION, "maas-region")
+        self.harness.set_leader(True)
         self.harness.begin()
-        self.harness.charm.unit.status = ops.BlockedStatus(
-            FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE
+        self.harness.charm._setup_network()
+        self.harness.charm.set_peer_data(
+            self.harness.charm.app,
+            S3_CONFIGURATION_BLOCKED_KEY,
+            FAILED_TO_ACCESS_CREATE_BUCKET_ERROR_MESSAGE,
         )
         self.harness.remove_relation(rel)
-        self.assertEqual(
-            self.harness.charm.unit.status,
-            ops.ActiveStatus(),
+        self.assertFalse(
+            self.harness.charm.get_peer_data(self.harness.charm.app, S3_CONFIGURATION_BLOCKED_KEY)
         )
+        self.harness.evaluate_status()
+        self.assertEqual(self.harness.charm.unit.status, ops.ActiveStatus())
 
+    @patch("charm.MaasHelper", autospec=True)
     @patch("backups.MAASBackups._run_backup")
     @patch("backups.MAASBackups._upload_content_to_s3")
     @patch("backups.MAASBackups._retrieve_s3_parameters")
     @patch("backups.MAASBackups._can_unit_perform_backup")
-    def test_on_create_backup_action(self, can_unit_backup, s3_params, upload_content, run_backup):
+    def test_on_create_backup_action(
+        self, can_unit_backup, s3_params, upload_content, run_backup, mock_helper
+    ):
+        self._satisfy_status_ladder(mock_helper)
         can_unit_backup.return_value = True, ""
         s3_params.return_value = ({}, [])
         self.harness.begin()
+        self.harness.charm._setup_network()
         self.harness.run_action("create-backup")
         can_unit_backup.assert_called_once()
         s3_params.assert_called_once()
         run_backup.assert_called_once()
         upload_content.assert_called_once()
-        self.assertIsInstance(self.harness.charm.unit.status, ops.ActiveStatus)
+        self.harness.evaluate_status()
+        self.assertEqual(self.harness.charm.unit.status, ops.ActiveStatus())
 
     @patch("backups.MAASBackups._can_unit_perform_backup")
     def test_on_create_backup_action_cannot_perform_backup(self, can_unit_backup):
@@ -952,7 +1004,8 @@ backup-id            | action      | status   | maas     | size       | controll
             self.harness.run_action("list-backups")
         err = e.exception
         self.assertEqual(
-            err.message, "Failed to list MAAS backups with error: An unspecified error occurred"
+            err.message,
+            "Failed to list MAAS backups with error: An unspecified error occurred",
         )
 
     @patch("charms.data_platform_libs.v0.s3.S3Requirer.get_s3_connection_info")
@@ -1109,7 +1162,8 @@ backup-id            | action      | status   | maas     | size       | controll
         download_file.side_effect = None
         buf_obj.getvalue.return_value = content.encode()
         self.assertEqual(
-            self.harness.charm.backup._read_content_from_s3(s3_path, s3_parameters), content
+            self.harness.charm.backup._read_content_from_s3(s3_path, s3_parameters),
+            content,
         )
         _named_temporary_file.assert_called_once()
         download_file.assert_called_once_with("test-path/test-file", buf_obj)
@@ -1558,7 +1612,10 @@ backup-id            | action      | status   | maas     | size       | controll
         self.harness.add_relation("s3-parameters", "s3-integrator")
         s3_parameters.return_value = {}, []
         action_event = MagicMock(spec=ops.ActionEvent)
-        action_event.params = {"backup-id": "2025-08-23T06:26:00Z", "controller-id": "abc123"}
+        action_event.params = {
+            "backup-id": "2025-08-23T06:26:00Z",
+            "controller-id": "abc123",
+        }
 
         self.assertTrue(self.harness.charm.backup._pre_restore_checks(event=action_event))
         action_event.fail.assert_not_called()
@@ -1620,7 +1677,10 @@ backup-id            | action      | status   | maas     | size       | controll
         self.harness.charm.unit.status = ops.BlockedStatus("fake blocked state")
         s3_parameters.return_value = {}, []
         action_event = MagicMock(spec=ops.ActionEvent)
-        action_event.params = {"backup-id": "2025-08-23T06:26:00Z", "controller-id": "abc123"}
+        action_event.params = {
+            "backup-id": "2025-08-23T06:26:00Z",
+            "controller-id": "abc123",
+        }
 
         self.assertFalse(self.harness.charm.backup._pre_restore_checks(event=action_event))
         action_event.fail.assert_called_once_with(
@@ -1634,7 +1694,10 @@ backup-id            | action      | status   | maas     | size       | controll
         self.harness.add_relation("maas-db", "postgresql")
         s3_parameters.return_value = {}, []
         action_event = MagicMock(spec=ops.ActionEvent)
-        action_event.params = {"backup-id": "2025-08-23T06:26:00Z", "controller-id": "abc123"}
+        action_event.params = {
+            "backup-id": "2025-08-23T06:26:00Z",
+            "controller-id": "abc123",
+        }
 
         self.assertFalse(self.harness.charm.backup._pre_restore_checks(event=action_event))
         action_event.fail.assert_called_once_with(
@@ -1643,13 +1706,15 @@ backup-id            | action      | status   | maas     | size       | controll
             "then retry this action",
         )
 
+    @patch("charm.MaasHelper", autospec=True)
     @patch("backups.MAASBackups._run_restore")
     @patch("backups.MAASBackups._list_backups")
     @patch("backups.MAASBackups._retrieve_s3_parameters")
     @patch("backups.MAASBackups._pre_restore_checks")
     def test_on_restore_backup_action(
-        self, pre_restore_checks, s3_params, list_backups, run_backup
+        self, pre_restore_checks, s3_params, list_backups, run_backup, mock_helper
     ):
+        self._satisfy_status_ladder(mock_helper)
         pre_restore_checks.return_value = True
         s3_params.return_value = (
             {
@@ -1664,14 +1729,17 @@ backup-id            | action      | status   | maas     | size       | controll
             {"id": "2025-08-23T06:26:00Z"},
         ]
         self.harness.begin()
+        self.harness.charm._setup_network()
         self.harness.run_action(
-            "restore-backup", {"backup-id": "2025-08-23T06:26:00Z", "controller-id": "abc123"}
+            "restore-backup",
+            {"backup-id": "2025-08-23T06:26:00Z", "controller-id": "abc123"},
         )
         pre_restore_checks.assert_called_once()
         s3_params.assert_called_once()
         list_backups.assert_called_once()
         run_backup.assert_called_once()
-        self.assertIsInstance(self.harness.charm.unit.status, ops.ActiveStatus)
+        self.harness.evaluate_status()
+        self.assertEqual(self.harness.charm.unit.status, ops.ActiveStatus())
 
     @patch("backups.MAASBackups._pre_restore_checks")
     def test_on_restore_backup_action__fail_pre_restore(self, pre_restore_checks):

--- a/maas-region/tests/unit/test_backup.py
+++ b/maas-region/tests/unit/test_backup.py
@@ -575,7 +575,7 @@ backup-id            | action      | status   | maas     | size       | controll
         }
         create_bucket.side_effect = ValueError()
         self.harness.begin()
-        # self.harness.add_relation(MAAS_REGION_RELATION, "maas-region")
+        self.harness.add_relation(MAAS_REGION_RELATION, "maas-region")
         self.harness.set_leader(True)
         self.harness.add_relation("s3-parameters", "s3-integrator", app_data=s3_parameters_dict)
         s3_parameters_dict["delete-older-than-days"] = 9999999
@@ -616,6 +616,23 @@ backup-id            | action      | status   | maas     | size       | controll
         self.harness.remove_relation(rel)
         self.assertFalse(
             self.harness.charm.get_peer_data(self.harness.charm.app, S3_CONFIGURATION_BLOCKED_KEY)
+        )
+        self.harness.evaluate_status()
+        self.assertEqual(self.harness.charm.unit.status, ops.ActiveStatus())
+
+    @patch("charm.MaasHelper", autospec=True)
+    def test_collect_status_s3_blocked_ignored_for_non_leader(self, mock_helper):
+        self._satisfy_status_ladder(mock_helper)
+        self.harness.add_relation(MAAS_REGION_RELATION, "maas-region")
+        self.harness.set_leader(False)
+        self.harness.begin()
+        self.harness.charm._setup_network()
+        app_name = self.harness.charm.app.name
+        # Simulate a blocked message in the data bag
+        self.harness.update_relation_data(
+            self.harness.charm.peers.id,
+            app_name,
+            {S3_CONFIGURATION_BLOCKED_KEY: '"some message"'},
         )
         self.harness.evaluate_status()
         self.assertEqual(self.harness.charm.unit.status, ops.ActiveStatus())

--- a/maas-region/tests/unit/test_backup.py
+++ b/maas-region/tests/unit/test_backup.py
@@ -518,7 +518,7 @@ backup-id            | action      | status   | maas     | size       | controll
             "delete-older-than-days": "9999999",
         }
         read_content.return_value = None
-        # self.harness.add_relation(MAAS_REGION_RELATION, "maas-region")
+        self.harness.add_relation(MAAS_REGION_RELATION, "maas-region")
         self.harness.set_leader(True)
         self.harness.begin()
         self.harness.charm._setup_network()

--- a/maas-region/tests/unit/test_charm.py
+++ b/maas-region/tests/unit/test_charm.py
@@ -364,8 +364,6 @@ class TestClusterUpdates(unittest.TestCase):
             args = configure_hosts.call_args.args
             self.assertEqual(args, ([ip_address("10.0.0.10")],))
 
-            self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
-
     def test_haproxy_relation__leader_sets_https_data(self):
         self.harness.set_leader(True)
 
@@ -400,8 +398,6 @@ class TestClusterUpdates(unittest.TestCase):
             args = configure_hosts.call_args.args
 
             self.assertEqual(args, ([ip_address("10.0.0.10")],))
-
-            self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
 
     def test_haproxy_relation__leader_has_correct_data(self):
         cases = [
@@ -482,11 +478,6 @@ class TestClusterUpdates(unittest.TestCase):
                     else:
                         self.assertNotIn("hosts", https_data)
 
-                if valid:
-                    self.assertEqual(harness.model.unit.status, ops.ActiveStatus())
-                else:
-                    self.assertNotEqual(harness.model.unit.status, ops.ActiveStatus())
-
     @patch("charm.MaasHelper", autospec=True)
     def test_haproxy_relation__reported_statuses(self, mock_helper):
         mock_helper.get_installed_version.return_value = "mock-ver"
@@ -565,6 +556,27 @@ class TestClusterUpdates(unittest.TestCase):
                     harness.add_relation_unit(rel_id, "haproxy/0")
                 harness.evaluate_status()
                 self.assertEqual(harness.model.unit.status, ops.BlockedStatus(expected_msg))
+
+    @patch("charm.MaasHelper", autospec=True)
+    def test_haproxy_relation__valid_topology_reaches_active(self, mock_helper):
+        mock_helper.get_installed_version.return_value = "mock-ver"
+        mock_helper.get_installed_channel.return_value = MAAS_SNAP_CHANNEL
+        mock_helper.is_maas_initialized.return_value = True
+        self.harness.set_leader(True)
+        self.harness.begin()
+        db_rel = self.harness.add_relation(MAAS_DB_NAME, "postgresql")
+        self.harness.update_relation_data(
+            db_rel,
+            "postgresql",
+            {
+                "endpoints": "30.0.0.1:5432",
+                "username": "test_maas_db",
+                "password": "my_secret",
+            },
+        )
+        # No HAProxy relations and no TLS config, valid topology
+        self.harness.evaluate_status()
+        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
 
 
 class TestCharmActions(unittest.TestCase):


### PR DESCRIPTION
The original issue was due to the movement of setting the charms `ActiveStatus` to determine the status outside of `_on_active_status`. This has a risk of increasing significantly increasing the complexity of the charm as we build more features on top. This change was implemented in https://github.com/canonical/maas-charms/pull/538 . 

We had to do this because there was previously no way of persisting a failed s3 credentials initialization. It wouldn't make sense to run these checks in every `_on_collect_status`, so we need an alternative solution to persist some state, i.e. that the s3 initialization has failed or succeeded. This solution proposes writing a failure message into the application databag. This idea is implemented in postgresql 16/edge (see https://github.com/canonical/postgresql-operator/blob/b99b84a4843c278b3c450e3db0268fdd3c93dd61/src/backups.py#L1567).

Notes:
- Writing a message instead of a boolean allows for future flexibility of notifications to the user, for example if we want to notify the user if the s3 has failed due to connection timeout or SSL errors which is currently not implemented. 
- We define a specific s3 configuration blocked key to be written into the databag. I've implemented this over a generic key so we can determine blocked status's from other future charm features which use other keys, and choose which priority to set them with. 
- Now, the only place where the charm is put into a blocked status is in `_on_collect_status`, so this should not interfere with other parts of the charm lifecycle

Resolves: #633