### PR TITLE
fix: allow resolute VMs to launch

### DIFF
--- a/maas-region/charmcraft.yaml
+++ b/maas-region/charmcraft.yaml
@@ -24,8 +24,6 @@ links:
     - https://github.com/canonical/maas-charms/issues
 
 platforms:
-  ubuntu@24.04:amd64:
-  ubuntu@24.04:arm64:
   ubuntu@26.04:amd64:
   ubuntu@26.04:arm64:
 

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -5,7 +5,9 @@
 
 import json
 import logging
+import os
 import platform
+import shutil
 import subprocess
 import tempfile
 from os import remove
@@ -36,14 +38,13 @@ class MaasHelper:
     """MAAS helper."""
 
     @staticmethod
-    def _daemon_reload_for_resolute() -> None:
+    def _fix_sbin_symlink_for_resolute() -> None:
         """Workaround for snap install failures on Ubuntu 26.04+ (Resolute).
 
-        Juju's remove-juju-services script placed at /sbin/remove-juju-services
-        prevents the /sbin -> /usr/sbin symlink from being created, causing
-        snapd to fail when trying to mount snap units. Running systemctl
-        daemon-reload before snap operations works around this by letting
-        systemd re-read unit files and recover from the broken state.
+        Juju 3.6 places a remove-juju-services script at /sbin/remove-juju-services,
+        which blocks the /sbin -> /usr/sbin merged-usr symlink from being created.
+        This causes snapd mount operations to fail. We fix this by moving the script
+        to /usr/sbin/ and re-creating the symlink.
 
         See: https://github.com/juju/juju/issues/22713
         """
@@ -54,13 +55,29 @@ class MaasHelper:
             version = os_release.get("VERSION_ID", "")
             if not version.startswith("26.04"):
                 return
+
+            sbin = Path("/sbin")
+            usr_sbin = Path("/usr/sbin")
+            remove_script = sbin / "remove-juju-services"
+            target = usr_sbin / "remove-juju-services"
+
+            if not remove_script.exists():
+                return
+
+            if sbin.is_symlink():
+                return
+
+            logger.info("Fixing /sbin -> /usr/sbin symlink for Resolute compatibility")
+            shutil.move(str(remove_script), str(target))
+            os.remove(sbin)
+            sbin.symlink_to("/usr/sbin")
             subprocess.run(
                 ["systemctl", "daemon-reload"],
                 capture_output=True,
                 check=False,
             )
         except Exception:
-            logger.debug("Failed to run daemon-reload workaround", exc_info=True)
+            logger.debug("Failed to fix /sbin symlink", exc_info=True)
 
     @staticmethod
     def install(channel: str) -> None:
@@ -69,7 +86,7 @@ class MaasHelper:
         Args:
             channel (str): snapstore channel
         """
-        MaasHelper._daemon_reload_for_resolute()
+        MaasHelper._fix_sbin_symlink_for_resolute()
         maas = SnapCache()[MAAS_SNAP_NAME]
         if not maas.present:
             maas.ensure(SnapState.Latest, channel=channel)

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+import platform
 import subprocess
 import tempfile
 from os import remove
@@ -35,12 +36,40 @@ class MaasHelper:
     """MAAS helper."""
 
     @staticmethod
+    def _daemon_reload_for_resolute() -> None:
+        """Workaround for snap install failures on Ubuntu 26.04+ (Resolute).
+
+        Juju's remove-juju-services script placed at /sbin/remove-juju-services
+        prevents the /sbin -> /usr/sbin symlink from being created, causing
+        snapd to fail when trying to mount snap units. Running systemctl
+        daemon-reload before snap operations works around this by letting
+        systemd re-read unit files and recover from the broken state.
+
+        See: https://github.com/juju/juju/issues/22713
+        """
+        try:
+            os_release = platform.freedesktop_os_release()
+            if os_release.get("ID") != "ubuntu":
+                return
+            version = os_release.get("VERSION_ID", "")
+            if not version.startswith("26.04"):
+                return
+            subprocess.run(
+                ["systemctl", "daemon-reload"],
+                capture_output=True,
+                check=False,
+            )
+        except Exception:
+            logger.debug("Failed to run daemon-reload workaround", exc_info=True)
+
+    @staticmethod
     def install(channel: str) -> None:
         """Install snap.
 
         Args:
             channel (str): snapstore channel
         """
+        MaasHelper._daemon_reload_for_resolute()
         maas = SnapCache()[MAAS_SNAP_NAME]
         if not maas.present:
             maas.ensure(SnapState.Latest, channel=channel)

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -42,10 +42,11 @@ class MaasHelper:
         """Workaround for snap install failures on Ubuntu 26.04+ (Resolute).
 
         Juju 3.6 places a remove-juju-services script at /sbin/remove-juju-services,
-        blocking the /sbin -> /usr/sbin merged-usr symlink. This causes snapd mount
-        operations to fail. We fix by moving the script to /usr/sbin/, restoring the
-        symlink, and restarting snapd so mount units are re-read against the correct
-        filesystem layout.
+        which forces /sbin to be a real directory instead of the /sbin -> /usr/sbin
+        merged-usr symlink that Ubuntu 26.04 expects. This breaks snapd, which looks
+        for mount helpers (mount.fuse, mount.fuse3) in /sbin. We move every entry in
+        /sbin into /usr/sbin, replace /sbin with the expected symlink, and restart
+        snapd so it re-reads its mount units against the corrected layout.
 
         See: https://github.com/juju/juju/issues/22713
         """
@@ -59,20 +60,25 @@ class MaasHelper:
 
             sbin = Path("/sbin")
             usr_sbin = Path("/usr/sbin")
-            remove_script = sbin / "remove-juju-services"
-            target = usr_sbin / "remove-juju-services"
 
-            if not remove_script.exists() and not sbin.exists():
-                return
-
+            # Already the expected merged-usr symlink, nothing to do.
             if sbin.is_symlink():
                 return
+            if not sbin.is_dir():
+                return
 
-            logger.info("Fixing /sbin -> /usr/sbin symlink for Resolute compatibility")
-            if remove_script.exists():
-                shutil.move(str(remove_script), str(target))
-            if sbin.exists():
-                os.remove(sbin)
+            logger.warning("Restoring /sbin -> /usr/sbin symlink for Resolute (juju#22713)")
+
+            # Move every entry in the real /sbin directory into /usr/sbin so that
+            # nothing is lost when we replace /sbin with a symlink.
+            for entry in sbin.iterdir():
+                dest = usr_sbin / entry.name
+                if dest.exists():
+                    os.remove(entry)
+                else:
+                    shutil.move(str(entry), str(dest))
+
+            os.rmdir(sbin)
             sbin.symlink_to("/usr/sbin")
 
             subprocess.run(
@@ -86,7 +92,7 @@ class MaasHelper:
                 check=False,
             )
         except Exception:
-            logger.debug("Failed to fix /sbin symlink", exc_info=True)
+            logger.warning("Failed to restore /sbin symlink", exc_info=True)
 
     @staticmethod
     def install(channel: str) -> None:

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -14,7 +14,7 @@ from os import remove
 from pathlib import Path
 
 import yaml
-from charms.operator_libs_linux.v2.snap import SnapCache, SnapState
+from charms.operator_libs_linux.v2.snap import SnapCache, SnapError, SnapState
 from tenacity import retry, stop_after_delay, wait_fixed
 
 MAAS_SNAP_NAME = "maas"
@@ -98,7 +98,19 @@ class MaasHelper:
         MaasHelper._fix_sbin_for_resolute()
         maas = SnapCache()[MAAS_SNAP_NAME]
         if not maas.present:
-            maas.ensure(SnapState.Latest, channel=channel)
+            try:
+                maas.ensure(SnapState.Latest, channel=channel)
+            except SnapError:
+                # The snap install may have failed due to stale snapd mount
+                # units. Run daemon-reload and retry once.
+                logger.info("Retrying snap installation after daemon-reload")
+                subprocess.run(
+                    ["systemctl", "daemon-reload"],
+                    capture_output=True,
+                    check=False,
+                )
+                maas = SnapCache()[MAAS_SNAP_NAME]
+                maas.ensure(SnapState.Latest, channel=channel)
             maas.hold()
 
     @staticmethod

--- a/maas-region/src/helper.py
+++ b/maas-region/src/helper.py
@@ -38,13 +38,14 @@ class MaasHelper:
     """MAAS helper."""
 
     @staticmethod
-    def _fix_sbin_symlink_for_resolute() -> None:
+    def _fix_sbin_for_resolute() -> None:
         """Workaround for snap install failures on Ubuntu 26.04+ (Resolute).
 
         Juju 3.6 places a remove-juju-services script at /sbin/remove-juju-services,
-        which blocks the /sbin -> /usr/sbin merged-usr symlink from being created.
-        This causes snapd mount operations to fail. We fix this by moving the script
-        to /usr/sbin/ and re-creating the symlink.
+        blocking the /sbin -> /usr/sbin merged-usr symlink. This causes snapd mount
+        operations to fail. We fix by moving the script to /usr/sbin/, restoring the
+        symlink, and restarting snapd so mount units are re-read against the correct
+        filesystem layout.
 
         See: https://github.com/juju/juju/issues/22713
         """
@@ -61,18 +62,26 @@ class MaasHelper:
             remove_script = sbin / "remove-juju-services"
             target = usr_sbin / "remove-juju-services"
 
-            if not remove_script.exists():
+            if not remove_script.exists() and not sbin.exists():
                 return
 
             if sbin.is_symlink():
                 return
 
             logger.info("Fixing /sbin -> /usr/sbin symlink for Resolute compatibility")
-            shutil.move(str(remove_script), str(target))
-            os.remove(sbin)
+            if remove_script.exists():
+                shutil.move(str(remove_script), str(target))
+            if sbin.exists():
+                os.remove(sbin)
             sbin.symlink_to("/usr/sbin")
+
             subprocess.run(
                 ["systemctl", "daemon-reload"],
+                capture_output=True,
+                check=False,
+            )
+            subprocess.run(
+                ["systemctl", "restart", "snapd.service", "snapd.socket"],
                 capture_output=True,
                 check=False,
             )
@@ -86,7 +95,7 @@ class MaasHelper:
         Args:
             channel (str): snapstore channel
         """
-        MaasHelper._fix_sbin_symlink_for_resolute()
+        MaasHelper._fix_sbin_for_resolute()
         maas = SnapCache()[MAAS_SNAP_NAME]
         if not maas.present:
             maas.ensure(SnapState.Latest, channel=channel)


### PR DESCRIPTION
- remove ubuntu 24.04 from charmcraft
- add systemctl reload workaround for snapd failure

see: https://github.com/juju/juju/issues/22713